### PR TITLE
Feat/reports logic

### DIFF
--- a/backend/src/controllers/reportsController.js
+++ b/backend/src/controllers/reportsController.js
@@ -1,5 +1,6 @@
 import pool from "../db/pool.js";
 
+//GET /api/reports
 export const getReports = async (req, res) => {
   try {
     const { id_empresa } = req.empresa
@@ -20,6 +21,7 @@ export const getReports = async (req, res) => {
   }
 }
 
+//GET /api/reports/:id
 export const getReportById = async (req, res) => {
   try {
     const { id } = req.params
@@ -44,6 +46,7 @@ export const getReportById = async (req, res) => {
   }
 }
 
+//POST /api/reports
 export const createReport = async (req, res) => {
   try {
     const { titulo, tipo, contenido_url, id_proyecto } = req.body
@@ -73,6 +76,7 @@ export const createReport = async (req, res) => {
   }
 }
 
+//PUT /api/reports/:id
 export const updateReport = async (req, res) => {
   try {
     const { id } = req.params
@@ -101,6 +105,7 @@ export const updateReport = async (req, res) => {
   }
 }
 
+//DELETE /api/reports/:id
 export const deleteReport = async (req, res) => {
   try {
     const { id } = req.params
@@ -127,6 +132,7 @@ export const deleteReport = async (req, res) => {
   }
 }
 
+//GET /api/reports/summary
 export const getCompanySummary = async (req, res) => {
   try {
     const { id_empresa } = req.empresa

--- a/backend/src/controllers/reportsController.js
+++ b/backend/src/controllers/reportsController.js
@@ -1,125 +1,201 @@
 import pool from "../db/pool.js";
 
-/**
- * Reports controller.
- * Handles CRUD operations for the reporte table.
- * Expected route prefix: /api/reports
- */
-
-/**
- * GET /api/reports
- * Returns all reports from the database.
- */
 export const getReports = async (req, res) => {
-    try {
-        const result = await pool.query(`
-            SELECT * FROM reporte
-            `
-        )
-        return res.status(200).json({ success: true, data: result.rows })
-    } catch (error) {
-        return res.status(500).json({ error: error })
-    }
+  try {
+    const { id_empresa } = req.empresa
+
+    const result = await pool.query(
+      `SELECT r.*
+       FROM public.reporte r
+       JOIN public.proyecto p ON p.id_proyecto = r.id_proyecto
+       WHERE p.id_empresa = $1
+       ORDER BY r.fecha_generacion DESC`,
+      [id_empresa]
+    )
+
+    return res.status(200).json({ success: true, data: result.rows })
+  } catch (error) {
+    console.error(error)
+    return res.status(500).json({ success: false, message: 'Server error.' })
+  }
 }
 
-/**
- * GET /api/reports/:id
- * Params:
- *   id - report ID
- * Returns the requested report or 404 if not found.
- */
 export const getReportById = async (req, res) => {
-    try {
-        const { id } = req.params
-        const result = await pool.query(`
-                SELECT * FROM reporte WHERE id_reporte = $1
-            `, [id])
+  try {
+    const { id } = req.params
+    const { id_empresa } = req.empresa
 
-        if (!result.rows.length) {
-            return res.status(404).json({ success: false, message: "Report not found" })
-        }
+    const result = await pool.query(
+      `SELECT r.*
+       FROM public.reporte r
+       JOIN public.proyecto p ON p.id_proyecto = r.id_proyecto
+       WHERE r.id_reporte = $1 AND p.id_empresa = $2`,
+      [id, id_empresa]
+    )
 
-        return res.status(200).json({ success: true, data: result.rows[0] })
-    } catch (error) {
-        return res.status(500).json({ success: false, error: error })
+    if (!result.rows.length) {
+      return res.status(404).json({ success: false, message: 'Report not found.' })
     }
+
+    return res.status(200).json({ success: true, data: result.rows[0] })
+  } catch (error) {
+    console.error(error)
+    return res.status(500).json({ success: false, message: 'Server error.' })
+  }
 }
 
-/**
- * POST /api/reports
- * Body: { titulo, tipo, contenido_url, id_proyecto, id_usuario }
- * Creates a new report entry.
- */
 export const createReport = async (req, res) => {
-    try {
-        const { titulo, tipo, contenido_url, id_proyecto, id_usuario } = req.body;
+  try {
+    const { titulo, tipo, contenido_url, id_proyecto } = req.body
+    const id_usuario = req.user.id_usuario
+    const { id_empresa } = req.empresa
 
-        await pool.query(`
-            INSERT INTO reporte (titulo, tipo, contenido_url, id_proyecto, id_usuario)
-            VALUES ($1, $2, $3, $4, $5)
-        `, [titulo, tipo, contenido_url, id_proyecto, id_usuario]);
+    const projectCheck = await pool.query(
+      `SELECT id_proyecto FROM public.proyecto WHERE id_proyecto = $1 AND id_empresa = $2`,
+      [id_proyecto, id_empresa]
+    )
 
-        return res.status(201).json({ success: true, message: "Report created successfully" });
-    } catch (error) {
-        console.error('Error creating report:', error); // Log internally
-        return res.status(500).json({ success: false, error: 'Internal server error' });
+    if (!projectCheck.rows.length) {
+      return res.status(404).json({ success: false, message: 'Project not found.' })
     }
-};
 
-/**
- * PUT /api/reports/:id
- * Params:
- *   id - report ID
- * Body: { titulo, tipo, contenido_url, id_proyecto }
- * Updates an existing report.
- */
-export const updateReport = async (req, res) => {
-    try {
-        const { id } = req.params
-        const { titulo, tipo, contenido_url, id_proyecto } = req.body
+    const result = await pool.query(
+      `INSERT INTO public.reporte (titulo, tipo, contenido_url, id_proyecto, id_usuario)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING *`,
+      [titulo, tipo, contenido_url, id_proyecto, id_usuario]
+    )
 
-        const result = await pool.query(`
-                UPDATE reporte SET titulo = $1, tipo = $2, 
-                contenido_url = $3, id_proyecto = $4
-                WHERE id_reporte = $5 RETURNING *
-            `, [titulo, tipo, contenido_url, id_proyecto, id])
-
-        if (!result.rows.length) {
-            return res.status(404).json({ success: false, message: "Report not found" })
-        }
-
-        return res.status(200).json({ success: true, data: result.rows[0] })
-
-    } catch (error) {
-        console.error(error)
-        res.status(500).json({ success: false, message: "Server error" })
-    }
+    return res.status(201).json({ success: true, data: result.rows[0] })
+  } catch (error) {
+    console.error(error)
+    return res.status(500).json({ success: false, message: 'Server error.' })
+  }
 }
 
-/**
- * DELETE /api/reports/:id
- * Params:
- *   id - report ID
- * Deletes the requested report.
- */
-export const deleteReport = async (req, res) => {
-    try {
-        const { id } = req.params
+export const updateReport = async (req, res) => {
+  try {
+    const { id } = req.params
+    const { titulo, tipo, contenido_url } = req.body
+    const { id_empresa } = req.empresa
 
-        const existing = await pool.query(`
-            SELECT * FROM reporte WHERE id_reporte = $1
-            `, [id])
+    const result = await pool.query(
+      `UPDATE public.reporte r
+       SET titulo = $1, tipo = $2, contenido_url = $3
+       FROM public.proyecto p
+       WHERE r.id_proyecto = p.id_proyecto
+         AND r.id_reporte = $4
+         AND p.id_empresa = $5
+       RETURNING r.*`,
+      [titulo, tipo, contenido_url, id, id_empresa]
+    )
 
-        if (!existing.rows.length) {
-            return res.status(404).json({ success: false, message: "Report not found" })
-        }
-
-        const result = await pool.query(`
-            DELETE FROM reporte WHERE id_reporte = $1
-            `, [id])
-
-        return res.status(200).json({ success: true, message: "Report deleted" })
-    } catch (error) {
-        return res.status(500).json({ success: false, message: "Server error" })
+    if (!result.rows.length) {
+      return res.status(404).json({ success: false, message: 'Report not found.' })
     }
+
+    return res.status(200).json({ success: true, data: result.rows[0] })
+  } catch (error) {
+    console.error(error)
+    return res.status(500).json({ success: false, message: 'Server error.' })
+  }
+}
+
+export const deleteReport = async (req, res) => {
+  try {
+    const { id } = req.params
+    const { id_empresa } = req.empresa
+
+    const result = await pool.query(
+      `DELETE FROM public.reporte r
+       USING public.proyecto p
+       WHERE r.id_proyecto = p.id_proyecto
+         AND r.id_reporte = $1
+         AND p.id_empresa = $2
+       RETURNING r.id_reporte`,
+      [id, id_empresa]
+    )
+
+    if (!result.rows.length) {
+      return res.status(404).json({ success: false, message: 'Report not found.' })
+    }
+
+    return res.status(200).json({ success: true, message: 'Report deleted.' })
+  } catch (error) {
+    console.error(error)
+    return res.status(500).json({ success: false, message: 'Server error.' })
+  }
+}
+
+export const getCompanySummary = async (req, res) => {
+  try {
+    const { id_empresa } = req.empresa
+
+    const result = await pool.query(
+      `SELECT
+         p.id_proyecto,
+         p.nombre,
+         p.descripcion,
+         p.estado,
+         p.fecha_inicio,
+         p.fecha_fin_planificada,
+         p.presupuesto_total,
+         COALESCE(t.total_tareas, 0)       AS total_tareas,
+         COALESCE(t.tareas_completadas, 0) AS tareas_completadas,
+         COALESCE(b.total_planificado, 0)  AS presupuesto_planificado,
+         COALESCE(b.total_real, 0)         AS presupuesto_real,
+         COALESCE(pr.progreso_actual, 0)   AS progreso_actual
+       FROM public.proyecto p
+       LEFT JOIN (
+         SELECT id_proyecto,
+           COUNT(*)::int                                          AS total_tareas,
+           COUNT(*) FILTER (WHERE estado = 'COMPLETADA')::int    AS tareas_completadas
+         FROM public.tarea
+         GROUP BY id_proyecto
+       ) t ON t.id_proyecto = p.id_proyecto
+       LEFT JOIN (
+         SELECT id_proyecto,
+           COALESCE(SUM(monto_planificado), 0) AS total_planificado,
+           COALESCE(SUM(monto_real), 0)        AS total_real
+         FROM public.presupuesto_actividad
+         GROUP BY id_proyecto
+       ) b ON b.id_proyecto = p.id_proyecto
+       LEFT JOIN LATERAL (
+         SELECT progress_percentage AS progreso_actual
+         FROM public.project_progress_entry
+         WHERE id_proyecto = p.id_proyecto
+         ORDER BY happened_at DESC, id_progress_entry DESC
+         LIMIT 1
+       ) pr ON true
+       WHERE p.id_empresa = $1
+       ORDER BY p.fecha_inicio DESC`,
+      [id_empresa]
+    )
+
+    const proyectos = result.rows.map(p => {
+      const totalTareas = Number(p.total_tareas)
+      const tareasCompletadas = Number(p.tareas_completadas)
+      const progresoEntrada = Number(p.progreso_actual)
+
+      const progreso = progresoEntrada > 0
+        ? progresoEntrada
+        : totalTareas > 0
+          ? Math.round((tareasCompletadas / totalTareas) * 100)
+          : 0
+
+      return { ...p, progreso_actual: progreso }
+    })
+
+    const totales = {
+      total_proyectos:        proyectos.length,
+      proyectos_activos:      proyectos.filter(p => p.estado === 'EN_PROGRESO').length,
+      proyectos_completados:  proyectos.filter(p => p.estado === 'COMPLETADO').length,
+      presupuesto_total:      proyectos.reduce((sum, p) => sum + Number(p.presupuesto_total ?? 0), 0),
+    }
+
+    return res.status(200).json({ success: true, data: { totales, proyectos } })
+  } catch (error) {
+    console.error(error)
+    return res.status(500).json({ success: false, message: 'Server error.' })
+  }
 }

--- a/backend/src/controllers/reportsController.js
+++ b/backend/src/controllers/reportsController.js
@@ -140,8 +140,10 @@ export const getCompanySummary = async (req, res) => {
          p.fecha_inicio,
          p.fecha_fin_planificada,
          p.presupuesto_total,
-         COALESCE(t.total_tareas, 0)       AS total_tareas,
+         COALESCE(t.total_tareas, 0)        AS total_tareas,
          COALESCE(t.tareas_completadas, 0) AS tareas_completadas,
+         COALESCE(t.tareas_en_progreso, 0) AS tareas_en_progreso,
+         COALESCE(t.tareas_pendientes, 0)  AS tareas_pendientes,
          COALESCE(b.total_planificado, 0)  AS presupuesto_planificado,
          COALESCE(b.total_real, 0)         AS presupuesto_real,
          COALESCE(pr.progreso_actual, 0)   AS progreso_actual
@@ -149,7 +151,9 @@ export const getCompanySummary = async (req, res) => {
        LEFT JOIN (
          SELECT id_proyecto,
            COUNT(*)::int                                          AS total_tareas,
-           COUNT(*) FILTER (WHERE estado = 'COMPLETADA')::int    AS tareas_completadas
+           COUNT(*) FILTER (WHERE estado = 'COMPLETADA')::int    AS tareas_completadas,
+           COUNT(*) FILTER (WHERE estado = 'EN_PROGRESO')::int   AS tareas_en_progreso,
+           COUNT(*) FILTER (WHERE estado = 'PENDIENTE')::int     AS tareas_pendientes
          FROM public.tarea
          GROUP BY id_proyecto
        ) t ON t.id_proyecto = p.id_proyecto

--- a/backend/src/routes/reportsRoutes.js
+++ b/backend/src/routes/reportsRoutes.js
@@ -1,15 +1,25 @@
-import { Router } from "express";
+import { Router } from 'express'
 import requireAuth from '../middleware/requireAuth.js'
-import requireRole from '../middleware/requireRole.js'
-import { getReports, getReportById, createReport, updateReport, deleteReport } from "../controllers/reportsController.js";
+import requireCompany from '../middleware/requireCompany.js'
+import requireCompanyRole from '../middleware/requireCompanyRole.js'
+import {
+  getReports,
+  getReportById,
+  createReport,
+  updateReport,
+  deleteReport,
+  getCompanySummary,
+} from '../controllers/reportsController.js'
 
 const router = Router()
-router.use(requireAuth)
 
-router.get("/", getReports)
-router.get("/:id", getReportById)
-router.post("/", requireRole('admin', 'manager', 'collaborator'), createReport)
-router.put("/:id", requireRole('admin', 'manager'), updateReport)
-router.delete("/:id", requireRole('admin'), deleteReport)
+router.use(requireAuth, requireCompany)
+
+router.get('/summary', getCompanySummary)
+router.get('/', getReports)
+router.get('/:id', getReportById)
+router.post('/', requireCompanyRole('owner', 'admin', 'manager'), createReport)
+router.put('/:id', requireCompanyRole('owner', 'admin', 'manager'), updateReport)
+router.delete('/:id', requireCompanyRole('owner', 'admin'), deleteReport)
 
 export default router

--- a/backend/src/routes/reportsRoutes.js
+++ b/backend/src/routes/reportsRoutes.js
@@ -2,6 +2,12 @@ import { Router } from 'express'
 import requireAuth from '../middleware/requireAuth.js'
 import requireCompany from '../middleware/requireCompany.js'
 import requireCompanyRole from '../middleware/requireCompanyRole.js'
+import validate from '../middleware/validate.js'
+import {
+  createReportSchema,
+  updateReportSchema,
+  reportIdParamSchema,
+} from '../schemas/reportsSchemas.js'
 import {
   getReports,
   getReportById,
@@ -17,9 +23,9 @@ router.use(requireAuth, requireCompany)
 
 router.get('/summary', getCompanySummary)
 router.get('/', getReports)
-router.get('/:id', getReportById)
-router.post('/', requireCompanyRole('owner', 'admin', 'manager'), createReport)
-router.put('/:id', requireCompanyRole('owner', 'admin', 'manager'), updateReport)
-router.delete('/:id', requireCompanyRole('owner', 'admin'), deleteReport)
+router.get('/:id', validate(reportIdParamSchema, 'params'), getReportById)
+router.post('/', requireCompanyRole('owner', 'admin', 'manager'), validate(createReportSchema), createReport)
+router.put('/:id', requireCompanyRole('owner', 'admin', 'manager'), validate(reportIdParamSchema, 'params'), validate(updateReportSchema), updateReport)
+router.delete('/:id', requireCompanyRole('owner', 'admin'), validate(reportIdParamSchema, 'params'), deleteReport)
 
 export default router

--- a/backend/src/schemas/reportsSchemas.js
+++ b/backend/src/schemas/reportsSchemas.js
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+
+export const VALID_TIPOS_REPORTE = ['AVANCE', 'PRESUPUESTO', 'INCIDENTE', 'CONSOLIDADO']
+
+export const createReportSchema = z.object({
+  titulo:        z.string().min(1, 'Title is required.').max(200),
+  tipo:          z.enum(VALID_TIPOS_REPORTE, { message: `Type must be one of: ${VALID_TIPOS_REPORTE.join(', ')}.` }),
+  contenido_url: z.string().url('Must be a valid URL.').optional().nullable(),
+  id_proyecto:   z.number().int().positive('Project ID must be a positive integer.'),
+})
+
+export const updateReportSchema = z
+  .object({
+    titulo:        z.string().min(1).max(200).optional(),
+    tipo:          z.enum(VALID_TIPOS_REPORTE, { message: `Type must be one of: ${VALID_TIPOS_REPORTE.join(', ')}.` }).optional(),
+    contenido_url: z.string().url('Must be a valid URL.').nullable().optional(),
+  })
+  .refine(
+    (data) => Object.keys(data).length > 0,
+    { message: 'No fields were provided for update.' }
+  )
+
+export const reportIdParamSchema = z.object({
+  id: z.coerce.number().int().positive({ message: 'Report ID must be a positive integer.' }),
+})

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,637 @@
+{
+  "name": "@control/frontend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@control/frontend",
+      "version": "1.0.0",
+      "dependencies": {
+        "@vueuse/core": "^14.2.1",
+        "gsap": "^3.14.2",
+        "lenis": "^1.3.23",
+        "lucide-vue-next": "^1.0.0",
+        "ogl": "^1.0.11",
+        "pinia": "^2.2.0",
+        "three": "^0.183.2",
+        "vue": "^3.5.0",
+        "vue-router": "^4.4.0"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-vue": "^5.1.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.32",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/shared": "3.5.32",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.32",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.32",
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.32",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/compiler-core": "3.5.32",
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.8",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.32",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.32",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.32",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.32",
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.32",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.32",
+        "@vue/runtime-core": "3.5.32",
+        "@vue/shared": "3.5.32",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.32",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32"
+      },
+      "peerDependencies": {
+        "vue": "3.5.32"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.32",
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "14.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "14.2.1",
+        "@vueuse/shared": "14.2.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "14.2.1",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "14.2.1",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gsap": {
+      "version": "3.14.2",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
+    },
+    "node_modules/lenis": {
+      "version": "1.3.23",
+      "resolved": "https://registry.npmjs.org/lenis/-/lenis-1.3.23.tgz",
+      "integrity": "sha512-YxYq3TJqj9sJNv0V9SkyQHejt14xwyIwgDaaMK89Uf9SxQfIszu+gTQSSphh6BWlLTNVKvvXAGkg+Zf+oFIevg==",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*",
+        "playground",
+        "playground/*"
+      ],
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/darkroomengineering"
+      },
+      "peerDependencies": {
+        "@nuxt/kit": ">=3.0.0",
+        "react": ">=17.0.0",
+        "vue": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nuxt/kit": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lucide-vue-next": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/ogl": {
+      "version": "1.0.11",
+      "license": "Unlicense"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pinia": {
+      "version": "2.3.1",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.3",
+        "vue-demi": "^0.14.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.4.4",
+        "vue": "^2.7.0 || ^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.183.2",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.32",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-sfc": "3.5.32",
+        "@vue/runtime-dom": "3.5.32",
+        "@vue/server-renderer": "3.5.32",
+        "@vue/shared": "3.5.32"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-demi": {
+      "version": "0.14.10",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    }
+  }
+}

--- a/frontend/src/views/ReportDetailView.vue
+++ b/frontend/src/views/ReportDetailView.vue
@@ -29,12 +29,7 @@
                 <p class="proj-desc">{{ project.descripcion || 'No description provided.' }}</p>
               </div>
               <div class="header-actions">
-                <Pill
-                  :label="statusPill(project.estado).label"
-                  :btnColor="statusPill(project.estado).bg"
-                  :circleColor="statusPill(project.estado).color"
-                  :textColor="statusPill(project.estado).color"
-                />
+              
                 <button class="btn-outline">
                   <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
                     <path d="M6 9V2M3 6l3 3 3-3M1 10h10" stroke="currentColor" stroke-width="1.2" stroke-linecap="square"/>
@@ -59,20 +54,17 @@
               </div>
               <div class="meta-item">
                 <span class="meta-label">Progress</span>
-                <span class="meta-value">{{ mock.budgetUsedPct }}%</span>
+                <span class="meta-value">{{ progressPct }}%</span>
               </div>
-              <div class="meta-item">
-                <span class="meta-label">Project ID</span>
-                <span class="meta-value dim">#{{ project.id_proyecto }}</span>
-              </div>
+              
             </div>
 
             <!-- Overall progress bar -->
             <div class="overall-progress">
               <div class="op-track">
-                <div class="op-fill" :style="{ width: mock.budgetUsedPct + '%' }"></div>
+                <div class="op-fill" :style="{ width: progressPct + '%' }"></div>
               </div>
-              <span class="op-label">{{ mock.budgetUsedPct }}% complete</span>
+              <span class="op-label">{{ progressPct }}% complete</span>
             </div>
           </div>
 
@@ -89,17 +81,17 @@
           <div class="detail-card">
             <div class="card-header">
               <span class="card-title">Budget Overview</span>
-              <span class="card-tag">Q{{ mock.quarter }} {{ mock.year }}</span>
+              <span class="card-tag">{{ budgetData.pct }}% used</span>
             </div>
             <div class="budget-body">
               <div class="donut-wrap">
                 <DonutChart
-                  :pct="mock.budgetUsedPct"
+                  :pct="budgetData.pct"
                   color="#c9a962"
-                  :size="80" :radius="28" :stroke-width="10"
-                  :label="`${mock.budgetUsedPct}%`" label-color="#c9a962" :label-font-size="11" :label-offset-y="3"
+                  :size="70" :radius="28" :stroke-width="10"
+                  :label="`${budgetData.pct}%`" label-color="#c9a962" :label-font-size="11" :label-offset-y="3"
                   sublabel="used" :sublabel-font-size="6" :sublabel-offset-y="10"
-                  display-width="72px"
+                  display-width="120px"
                 />
               </div>
               <div class="budget-stats">
@@ -108,30 +100,13 @@
                   <span class="bstat-label">Total Budget</span>
                 </div>
                 <div class="bstat">
-                  <span class="bstat-val">{{ formatBudget(mock.budgetSpent) }}</span>
+                  <span class="bstat-val">{{ formatBudget(budgetData.real) }}</span>
                   <span class="bstat-label">Spent</span>
                 </div>
                 <div class="bstat">
-                  <span class="bstat-val" style="color:#4ade80">{{ formatBudget(mock.budgetRemaining) }}</span>
+                  <span class="bstat-val" style="color:#4ade80">{{ formatBudget(budgetData.remaining) }}</span>
                   <span class="bstat-label">Remaining</span>
                 </div>
-              </div>
-            </div>
-            <div class="budget-bars">
-              <div class="bb-item">
-                <span class="bb-label">Operational</span>
-                <div class="bb-track"><div class="bb-fill gold" :style="{ width: mock.opPct + '%' }"></div></div>
-                <span class="bb-pct">{{ mock.opPct }}%</span>
-              </div>
-              <div class="bb-item">
-                <span class="bb-label">Personnel</span>
-                <div class="bb-track"><div class="bb-fill blue" :style="{ width: mock.personnelPct + '%' }"></div></div>
-                <span class="bb-pct">{{ mock.personnelPct }}%</span>
-              </div>
-              <div class="bb-item">
-                <span class="bb-label">Equipment</span>
-                <div class="bb-track"><div class="bb-fill purple" :style="{ width: mock.equipPct + '%' }"></div></div>
-                <span class="bb-pct">{{ mock.equipPct }}%</span>
               </div>
             </div>
           </div>
@@ -140,53 +115,54 @@
           <div class="detail-card">
             <div class="card-header">
               <span class="card-title">Task Management</span>
-              <span class="card-tag">{{ mock.totalTasks }} tasks</span>
+              <span class="card-tag">{{ tasksByState.total }} tasks</span>
             </div>
             <div class="task-completion-circle">
               <DonutChart
-                :pct="mock.tasksCompletedPct"
+                :pct="tasksByState.total ? Math.round(tasksByState.completadas / tasksByState.total * 100) : 0"
                 color="#4ade80"
                 :size="60" :radius="22" :stroke-width="8"
-                :label="`${mock.tasksCompletedPct}%`" label-color="#fff" :label-font-size="9" :label-offset-y="3"
-                display-width="56px"
+                :label="tasksByState.total ? Math.round(tasksByState.completadas / tasksByState.total * 100) + '%' : '0%'"
+                label-color="#fff" :label-font-size="9" :label-offset-y="3"
+                display-width="90px"
               />
               <div class="task-summary">
-                <span class="ts-big">{{ mock.tasksCompleted }} / {{ mock.totalTasks }}</span>
+                <span class="ts-big">{{ tasksByState.completadas }} / {{ tasksByState.total }}</span>
                 <span class="ts-label">tasks completed</span>
               </div>
             </div>
             <div class="task-list">
               <div class="tl-row">
-                <span class="tl-dot green"></span>
-                <span class="tl-label">Completed</span>
-                <div class="tl-bar-wrap">
-                  <div class="tl-track"><div class="tl-fill green" :style="{ width: (mock.tasksCompleted / mock.totalTasks * 100) + '%' }"></div></div>
-                </div>
-                <span class="tl-val">{{ mock.tasksCompleted }}</span>
-              </div>
-              <div class="tl-row">
                 <span class="tl-dot blue"></span>
-                <span class="tl-label">In Progress</span>
-                <div class="tl-bar-wrap">
-                  <div class="tl-track"><div class="tl-fill blue" :style="{ width: (mock.tasksInProgress / mock.totalTasks * 100) + '%' }"></div></div>
-                </div>
-                <span class="tl-val">{{ mock.tasksInProgress }}</span>
-              </div>
-              <div class="tl-row">
-                <span class="tl-dot gold"></span>
                 <span class="tl-label">Pending</span>
                 <div class="tl-bar-wrap">
-                  <div class="tl-track"><div class="tl-fill gold" :style="{ width: (mock.tasksPending / mock.totalTasks * 100) + '%' }"></div></div>
+                  <div class="tl-track"><div class="tl-fill blue" :style="{ width: tasksByState.total ? (tasksByState.pendientes / tasksByState.total * 100) + '%' : '0%' }"></div></div>
                 </div>
-                <span class="tl-val">{{ mock.tasksPending }}</span>
+                <span class="tl-val">{{ tasksByState.pendientes }}</span>
+              </div>
+              <div class="tl-row">
+                <span class="tl-dot green"></span>
+                <span class="tl-label">In Progress</span>
+                <div class="tl-bar-wrap">
+                  <div class="tl-track"><div class="tl-fill green" :style="{ width: tasksByState.total ? (tasksByState.enProgreso / tasksByState.total * 100) + '%' : '0%' }"></div></div>
+                </div>
+                <span class="tl-val">{{ tasksByState.enProgreso }}</span>
+              </div>
+              <div class="tl-row">
+                <span class="tl-dot gold"></span>    
+                <span class="tl-label">Completed</span>
+                <div class="tl-bar-wrap">
+                  <div class="tl-track"><div class="tl-fill gold" :style="{ width: tasksByState.total ? (tasksByState.completadas / tasksByState.total * 100) + '%' : '0%' }"></div></div>
+                </div>
+                <span class="tl-val">{{ tasksByState.completadas }}</span>
               </div>
               <div class="tl-row">
                 <span class="tl-dot red"></span>
-                <span class="tl-label">Blocked</span>
+                <span class="tl-label">Cancelled</span>
                 <div class="tl-bar-wrap">
-                  <div class="tl-track"><div class="tl-fill red" :style="{ width: (mock.tasksBlocked / mock.totalTasks * 100) + '%' }"></div></div>
+                  <div class="tl-track"><div class="tl-fill red" :style="{ width: tasksByState.total ? (tasksByState.canceladas / tasksByState.total * 100) + '%' : '0%' }"></div></div>
                 </div>
-                <span class="tl-val">{{ mock.tasksBlocked }}</span>
+                <span class="tl-val">{{ tasksByState.canceladas }}</span>
               </div>
             </div>
           </div>
@@ -195,18 +171,18 @@
           <div class="detail-card">
             <div class="card-header">
               <span class="card-title">Team</span>
-              <span class="card-tag">{{ mock.team.length }} members</span>
+              <span class="card-tag">{{ teamTotal }} members</span>
             </div>
             <div class="team-list">
-              <div v-for="member in mock.team" :key="member.name" class="member-row">
-                <div class="member-avatar" :style="{ background: member.avatarBg }">
-                  {{ member.initials }}
-                </div>
+              <div v-for="role in teamRoles" :key="role.rol" class="member-row">
+                <div class="member-avatar">{{ role.total }}</div>
                 <div class="member-info">
-                  <span class="member-name">{{ member.name }}</span>
-                  <span class="member-role">{{ member.role }}</span>
+                  <span class="member-name">{{ role.rol }}</span>
+                  <span class="member-role">{{ role.total }} member{{ role.total !== 1 ? 's' : '' }}</span>
                 </div>
-                <span class="member-status" :class="member.statusCls">{{ member.status }}</span>
+              </div>
+              <div v-if="!teamRoles.length" class="tl-label" style="color:#444; padding: 8px 0">
+                No team members assigned.
               </div>
             </div>
           </div>
@@ -252,71 +228,6 @@
             </div>
           </div>
 
-          <!-- Efficiency Metrics (full width) -->
-          <div class="detail-card span-2">
-            <div class="card-header">
-              <span class="card-title">Efficiency Metrics</span>
-              <div class="card-header-right">
-                <span
-                  v-for="p in ['1W','1M','3M']" :key="p"
-                  class="period-btn"
-                  :class="{ active: activePeriod === p }"
-                  @click="activePeriod = p"
-                >{{ p }}</span>
-              </div>
-            </div>
-            <div class="metrics-grid">
-              <div v-for="metric in mock.metrics" :key="metric.label" class="metric-card">
-                <div class="metric-top">
-                  <span class="metric-val" :style="{ color: metric.color }">{{ metric.value }}</span>
-                  <span class="metric-delta" :class="metric.deltaPos ? 'pos' : 'neg'">
-                    {{ metric.deltaPos ? '↑' : '↓' }} {{ metric.delta }}
-                  </span>
-                </div>
-                <span class="metric-label">{{ metric.label }}</span>
-                <div class="metric-sparkline">
-                  <svg :viewBox="`0 0 80 28`" preserveAspectRatio="none" class="spark-svg">
-                    <path :d="metric.spark" fill="none" :stroke="metric.color" stroke-width="1.5" opacity="0.7"/>
-                  </svg>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Recent Activity (full width) -->
-          <div class="detail-card span-2">
-            <div class="card-header">
-              <span class="card-title">Recent Activity</span>
-              <button class="view-all-btn">View all →</button>
-            </div>
-            <div class="activity-list">
-              <div v-for="act in mock.activity" :key="act.id" class="activity-row">
-                <div class="act-icon" :style="{ background: act.iconBg }">
-                  <svg v-if="act.type === 'task'" width="10" height="10" viewBox="0 0 10 10" fill="none">
-                    <rect x="1" y="1" width="8" height="8" rx="1" stroke="currentColor" stroke-width="1.1"/>
-                    <path d="M3 5l1.5 1.5 2.5-2.5" stroke="currentColor" stroke-width="1" stroke-linecap="square"/>
-                  </svg>
-                  <svg v-else-if="act.type === 'budget'" width="10" height="10" viewBox="0 0 10 10" fill="none">
-                    <circle cx="5" cy="5" r="4" stroke="currentColor" stroke-width="1.1"/>
-                    <path d="M5 2.5v5M3.5 3.5h2.5a1 1 0 0 1 0 2H3.5" stroke="currentColor" stroke-width="1" stroke-linecap="square"/>
-                  </svg>
-                  <svg v-else-if="act.type === 'member'" width="10" height="10" viewBox="0 0 10 10" fill="none">
-                    <circle cx="5" cy="3.5" r="1.8" stroke="currentColor" stroke-width="1.1"/>
-                    <path d="M1.5 9c0-2 1.6-3.5 3.5-3.5S8.5 7 8.5 9" stroke="currentColor" stroke-width="1.1" stroke-linecap="square"/>
-                  </svg>
-                  <svg v-else width="10" height="10" viewBox="0 0 10 10" fill="none">
-                    <path d="M5 1v4l2.5 1.5" stroke="currentColor" stroke-width="1.1" stroke-linecap="square"/>
-                    <circle cx="5" cy="5" r="4" stroke="currentColor" stroke-width="1.1"/>
-                  </svg>
-                </div>
-                <div class="act-content">
-                  <span class="act-text">{{ act.text }}</span>
-                  <span class="act-meta">{{ act.who }} · {{ act.time }}</span>
-                </div>
-                <span class="act-tag" :class="act.tagCls">{{ act.tag }}</span>
-              </div>
-            </div>
-          </div>
 
         </div>
       </div>
@@ -339,6 +250,7 @@
 
         <div class="side-section">
           <p class="side-label">Quick Stats</p>
+          
           <div class="qstat-list">
             <div class="qstat">
               <span class="qstat-label">Days Active</span>
@@ -354,46 +266,6 @@
               <span class="qstat-label">Budget / Day</span>
               <span class="qstat-val">{{ budgetPerDay }}</span>
             </div>
-            <div class="qstat">
-              <span class="qstat-label">Velocity</span>
-              <span class="qstat-val gold">{{ mock.velocity }} t/w</span>
-            </div>
-          </div>
-        </div>
-
-        <div class="side-divider"></div>
-
-        <div class="side-section">
-          <p class="side-label">Actions</p>
-          <div class="side-actions">
-            <Button label="Generate Report" />
-            <Button label="Add Member" />
-            <Button label="Settings" />
-          </div>
-        </div>
-
-        <div class="side-divider"></div>
-
-        <div class="side-section">
-          <p class="side-label">Project Info</p>
-          <div class="info-list">
-            <div class="info-row">
-              <span class="info-key">Status</span>
-              <Pill
-                :label="statusPill(project.estado).label"
-                :btnColor="statusPill(project.estado).bg"
-                :circleColor="statusPill(project.estado).color"
-                :textColor="statusPill(project.estado).color"
-              />
-            </div>
-            <div class="info-row">
-              <span class="info-key">Company</span>
-              <span class="info-val">#{{ project.id_empresa }}</span>
-            </div>
-            <div class="info-row">
-              <span class="info-key">Manager</span>
-              <span class="info-val">#{{ project.id_encargado }}</span>
-            </div>
             <div class="info-row">
               <span class="info-key">Budget</span>
               <span class="info-val gold">{{ formatBudget(project.presupuesto_total) }}</span>
@@ -403,19 +275,8 @@
 
         <div class="side-divider"></div>
 
-        <!-- Risk indicator -->
-        <div class="side-section">
-          <p class="side-label">Risk Level</p>
-          <div class="risk-bars">
-            <div v-for="r in mock.risks" :key="r.label" class="risk-row">
-              <span class="risk-label">{{ r.label }}</span>
-              <div class="risk-track">
-                <div class="risk-fill" :style="{ width: r.pct + '%', background: r.color }"></div>
-              </div>
-              <span class="risk-val" :style="{ color: r.color }">{{ r.level }}</span>
-            </div>
-          </div>
-        </div>
+        
+
 
       </aside>
 
@@ -436,20 +297,24 @@ import { useAuthStore } from '../stores/auth'
 const route     = useRoute()
 const authStore = useAuthStore()
 
-const project    = ref(null)
-const loading    = ref(true)
-const activePeriod = ref('1M')
+const project = ref(null)
+const metrics = ref(null)
+const loading = ref(true)
 
-// ── API ────────────────────────────────────────────────────────────────────
-async function loadProject() {
+async function loadAll() {
   loading.value = true
   try {
-    const res = await fetch(`/api/projects/${route.params.id}`, {
-      headers: { Authorization: `Bearer ${authStore.token}` },
-    })
-    if (!res.ok) throw new Error()
-    const json = await res.json()
-    project.value = json.data
+    const headers = {
+      Authorization: `Bearer ${authStore.token}`,
+      'X-Company-ID': String(authStore.idEmpresa),
+    }
+    const [projRes, metRes] = await Promise.all([
+      fetch(`/api/projects/${route.params.id}`, { headers }),
+      fetch(`/api/projects/${route.params.id}/metrics`, { headers }),
+    ])
+    if (!projRes.ok) throw new Error()
+    project.value = (await projRes.json()).data
+    if (metRes.ok) metrics.value = (await metRes.json()).data
   } catch {
     project.value = null
   } finally {
@@ -457,96 +322,40 @@ async function loadProject() {
   }
 }
 
-onMounted(loadProject)
+onMounted(loadAll)
 
+// ── Metrics-derived computeds ──────────────────────────────────────────────
+const progressPct = computed(() => metrics.value?.progress?.current_percentage ?? 0)
 
-// ── Seeded mock data (deterministic from project id) ──────────────────────
-function seeded(id, min, max) {
-  const s = Math.sin(id * 9301 + 49297) * 0.5 + 0.5
-  return Math.floor(s * (max - min + 1)) + min
-}
-
-const mock = computed(() => {
-  if (!project.value) return {}
-  const id = project.value.id_proyecto
-
-  const budgetUsedPct   = seeded(id,      35, 90)
-  const total           = parseFloat(project.value.presupuesto_total) || 100_000
-  const budgetSpent     = total * budgetUsedPct / 100
-  const budgetRemaining = total - budgetSpent
-
-  const opPct         = seeded(id + 1, 40, 70)
-  const personnelPct  = seeded(id + 2, 20, 50)
-  const equipPct      = seeded(id + 3, 10, 30)
-
-  const totalTasks        = seeded(id,     20, 80)
-  const tasksCompletedPct = seeded(id + 5, 40, 85)
-  const tasksCompleted    = Math.floor(totalTasks * tasksCompletedPct / 100)
-  const tasksInProgress   = seeded(id + 6, 3, Math.max(4, Math.floor(totalTasks * 0.2)))
-  const tasksPending      = Math.max(0, totalTasks - tasksCompleted - tasksInProgress - seeded(id + 7, 0, 3))
-  const tasksBlocked      = totalTasks - tasksCompleted - tasksInProgress - tasksPending
-
-  const names = [
-    { name: 'Anna Carter',   role: 'Project Lead',   initials: 'AC', avatarBg: 'rgba(201,169,98,0.15)',  statusCls: 'st-active',    status: 'Active'   },
-    { name: 'Carlos Reed',   role: 'Developer',      initials: 'CR', avatarBg: 'rgba(96,165,250,0.12)',  statusCls: 'st-active',    status: 'Active'   },
-    { name: 'Maya Lopez',    role: 'Designer',       initials: 'ML', avatarBg: 'rgba(167,139,250,0.12)', statusCls: 'st-idle',      status: 'Idle'     },
-    { name: 'Daniel Morris', role: 'QA Engineer',    initials: 'DM', avatarBg: 'rgba(74,222,128,0.1)',   statusCls: 'st-active',    status: 'Active'   },
-    { name: 'Sophie Harper', role: 'Analyst',        initials: 'SH', avatarBg: 'rgba(251,146,60,0.1)',   statusCls: 'st-away',      status: 'Away'     },
-  ]
-  const teamSize = seeded(id + 8, 2, 5)
-  const team = names.slice(0, teamSize)
-
-  const quarter = Math.ceil((new Date().getMonth() + 1) / 3)
-  const year    = new Date().getFullYear()
-
-  const velocity = seeded(id + 9, 6, 18)
-
-  const spark1 = `M0,20 C10,18 20,14 30,12 C40,10 50,8 60,6 C65,5 70,4 80,3`
-  const spark2 = `M0,22 C10,20 20,22 30,18 C40,14 50,16 60,12 C70,10 75,8 80,7`
-  const spark3 = `M0,24 C10,20 20,18 30,16 C40,14 50,12 60,14 C70,16 75,12 80,10`
-  const spark4 = `M0,18 C10,16 20,14 30,18 C40,22 50,16 60,12 C70,8 75,10 80,6`
-  const spark5 = `M0,20 C10,18 20,22 30,20 C40,18 50,14 60,16 C70,18 75,14 80,12`
-
-  const metrics = [
-    { label: 'ROI',               value: `${seeded(id+10,8,24)}%`,  color:'#c9a962', delta:`${seeded(id+11,1,5)}.${seeded(id+12,0,9)}%`, deltaPos:true,  spark:spark1 },
-    { label: 'Budget Efficiency', value: `${seeded(id+13,70,95)}%`, color:'#4ade80', delta:`${seeded(id+14,1,8)}%`,                       deltaPos:true,  spark:spark2 },
-    { label: 'Time Efficiency',   value: `${seeded(id+15,55,88)}%`, color:'#60a5fa', delta:`${seeded(id+16,1,6)}%`,                       deltaPos:false, spark:spark3 },
-    { label: 'Team Velocity',     value: `${velocity}t/w`,          color:'#a78bfa', delta:`${seeded(id+17,1,4)}`,                        deltaPos:true,  spark:spark4 },
-    { label: 'Risk Score',        value: `${seeded(id+18,10,45)}/100`,color:'#fb7185',delta:`${seeded(id+19,1,5)}`,                       deltaPos:false, spark:spark5 },
-  ]
-
-  const activities = [
-    { id:1, type:'task',   text:`Task "${project.value.nombre} — Sprint ${seeded(id,1,5)}" marked as complete`, who:'Anna Carter',   time:'2h ago',  tag:'Task',   tagCls:'tag-green'  },
-    { id:2, type:'budget', text:`Budget allocation updated: +${formatBudget(seeded(id+1,1000,8000))} approved`,  who:'Carlos Reed',   time:'5h ago',  tag:'Budget', tagCls:'tag-gold'   },
-    { id:3, type:'member', text:`Maya Lopez joined as Designer`,                                                 who:'System',        time:'1d ago',  tag:'Team',   tagCls:'tag-purple' },
-    { id:4, type:'status', text:`Project status changed to ${statusLabel(project.value.estado)}`,                who:'Daniel Morris', time:'2d ago',  tag:'Status', tagCls:'tag-blue'   },
-    { id:5, type:'task',   text:`${seeded(id+2,3,10)} tasks moved to In Progress`,                              who:'Anna Carter',   time:'3d ago',  tag:'Task',   tagCls:'tag-green'  },
-  ]
-
-  const risks = [
-    { label: 'Schedule',  pct: seeded(id+20,20,70), color:'#fb923c', level: seeded(id+20,20,70) > 50 ? 'High' : 'Medium' },
-    { label: 'Budget',    pct: seeded(id+21,10,60), color:'#fb7185', level: seeded(id+21,10,60) > 50 ? 'High' : 'Low'    },
-    { label: 'Technical', pct: seeded(id+22,15,55), color:'#a78bfa', level: seeded(id+22,15,55) > 40 ? 'Medium' : 'Low'  },
-  ]
-
-  return {
-    budgetUsedPct, budgetSpent, budgetRemaining,
-    opPct, personnelPct, equipPct,
-    totalTasks, tasksCompletedPct, tasksCompleted,
-    tasksInProgress, tasksPending, tasksBlocked: Math.max(0, tasksBlocked),
-    team, quarter, year, velocity,
-    metrics, activity: activities, risks,
-  }
+const tasksByState = computed(() => {
+  const rows = metrics.value?.tareas ?? []
+  const get = (estado) => Number(rows.find(r => r.estado === estado)?.count ?? 0)
+  const completadas = get('COMPLETADA')
+  const enProgreso  = get('EN_PROGRESO')
+  const pendientes  = get('PENDIENTE')
+  const canceladas  = get('CANCELADA')
+  const total = rows.reduce((s, r) => s + Number(r.count), 0)
+  return { total, completadas, enProgreso, pendientes, canceladas }
 })
 
-// ── Timeline (derived from project states) ────────────────────────────────
-const TIMELINE_PHASES = [
-  { key: 'PLANIFICADO', label: 'Planning',    desc: 'Scope definition, resource allocation and goal setting.' },
-  { key: 'EN_PROGRESO', label: 'Execution',   desc: 'Active development and task completion by the team.' },
-  { key: 'REVISION',    label: 'Review',      desc: 'Quality assurance, testing and stakeholder review.' },
-  { key: 'COMPLETADO',  label: 'Delivery',    desc: 'Final delivery, documentation and project closure.' },
-]
+const budgetData = computed(() => {
+  const b = metrics.value?.presupuesto
+  const planificado = Number(b?.total_planificado ?? 0)
+  const real        = Number(b?.total_real ?? 0)
+  const pct = planificado > 0 ? Math.min(Math.round((real / planificado) * 100), 100) : 0
+  return { planificado, real, pct, remaining: Math.max(planificado - real, 0) }
+})
 
+const teamRoles = computed(() => metrics.value?.equipo ?? [])
+const teamTotal = computed(() => teamRoles.value.reduce((s, r) => s + Number(r.total), 0))
+
+// ── Timeline ───────────────────────────────────────────────────────────────
+const TIMELINE_PHASES = [
+  { key: 'PLANIFICADO', label: 'Planning',  desc: 'Scope definition, resource allocation and goal setting.' },
+  { key: 'EN_PROGRESO', label: 'Execution', desc: 'Active development and task completion by the team.' },
+  { key: 'REVISION',    label: 'Review',    desc: 'Quality assurance, testing and stakeholder review.' },
+  { key: 'COMPLETADO',  label: 'Delivery',  desc: 'Final delivery, documentation and project closure.' },
+]
 const ESTADO_ORDER = ['PLANIFICADO', 'EN_PROGRESO', 'REVISION', 'COMPLETADO']
 
 const timelinePhases = computed(() => {
@@ -554,16 +363,15 @@ const timelinePhases = computed(() => {
   const estado = project.value.estado
   const isCancelled = estado === 'CANCELADO'
   const isPaused    = estado === 'PAUSADO'
-
   let currentIdx = ESTADO_ORDER.indexOf(estado)
-  if (currentIdx === -1) currentIdx = 1  // default to execution for PAUSADO/CANCELADO
+  if (currentIdx === -1) currentIdx = 1
 
   return TIMELINE_PHASES.map((phase, i) => {
     const phaseIdx = ESTADO_ORDER.indexOf(phase.key)
     let state = 'future'
-    if (isCancelled)       state = phaseIdx === 0 ? 'done' : 'skip'
-    else if (isPaused)     state = phaseIdx <  1  ? 'done' : phaseIdx === 1 ? 'current' : 'future'
-    else if (phaseIdx < currentIdx)  state = 'done'
+    if (isCancelled)              state = phaseIdx === 0 ? 'done' : 'skip'
+    else if (isPaused)            state = phaseIdx < 1 ? 'done' : phaseIdx === 1 ? 'current' : 'future'
+    else if (phaseIdx < currentIdx)   state = 'done'
     else if (phaseIdx === currentIdx) state = 'current'
 
     const startDate = project.value.fecha_inicio
@@ -574,7 +382,6 @@ const timelinePhases = computed(() => {
     } else if (state === 'future' && endDate && phaseIdx === TIMELINE_PHASES.length - 1) {
       dateStr = formatDate(endDate)
     }
-
     return { ...phase, state, date: dateStr }
   })
 })
@@ -853,7 +660,7 @@ const healthSub = computed(() => {
 
 /* ─── Budget card ────────────────────────────────────────────────────────── */
 .budget-body { display: flex; align-items: center; gap: 20px; margin-bottom: 16px; }
-.donut-wrap { flex-shrink: 0; }
+.donut-wrap { flex-shrink: 0; padding-right: 2rem; }
 .budget-stats { display: flex; flex-direction: column; gap: 8px; }
 .bstat { display: flex; flex-direction: column; }
 .bstat-val {

--- a/frontend/src/views/ReportsView.vue
+++ b/frontend/src/views/ReportsView.vue
@@ -14,7 +14,7 @@
             <p class="rep-subtitle">Analytics and performance overview for all your projects</p>
           </div>
           <div class="rep-header-actions">
-            <button class="btn-outline">
+            <button class="btn-outline" @click="openCreateModal">
               <svg class="icon14" viewBox="0 0 14 14" fill="none">
                 <path d="M7 2v10M2 7h10" stroke="currentColor" stroke-width="1.4" stroke-linecap="square"/>
               </svg>
@@ -46,44 +46,37 @@
             @click="activeFilter = f.key"
           >
             {{ f.label }}
-            <svg class="icon10 chevron" viewBox="0 0 10 10" fill="none">
-              <path d="M3 4l2 2 2-2" stroke="currentColor" stroke-width="1.2" stroke-linecap="square"/>
-            </svg>
           </button>
         </div>
 
         <!-- KPI Cards -->
         <div class="kpi-grid">
-          <Card title="32.5%" subtitle="ROI Growth"
-            back="rgba(255,255,255,0.03)" titleColor="#faf8f5"
-            borderColor="#1e1e1e" shadowColor="rgba(0,0,0,0.25)">
-            <Pill label="+12.3%" btnColor="rgba(74,222,128,0.1)" circleColor="#4ade80" textColor="#4ade80" />
-          </Card>
-
-          <Card :title="loading ? '—' : String(projects.length)" subtitle="Active Projects"
-            back="rgba(255,255,255,0.03)" titleColor="#faf8f5"
-            borderColor="#1e1e1e" shadowColor="rgba(0,0,0,0.25)">
-            <Pill label="+8.2%" btnColor="rgba(74,222,128,0.1)" circleColor="#4ade80" textColor="#4ade80" />
-          </Card>
-
-          <Card :title="loading ? '—' : String(completedCount)" subtitle="Completed"
-            back="rgba(255,255,255,0.03)" titleColor="#faf8f5"
-            borderColor="#1e1e1e" shadowColor="rgba(0,0,0,0.25)">
-            <Pill label="+15" btnColor="rgba(167,139,250,0.1)" circleColor="#a78bfa" textColor="#a78bfa" />
-          </Card>
-
-          <Card :title="loading ? '—' : formatBudget(totalBudget)" subtitle="Budget Total"
-            back="rgba(255,255,255,0.03)" titleColor="#faf8f5"
-            borderColor="#1e1e1e" shadowColor="rgba(0,0,0,0.25)">
-            <Pill label="-2.1%" btnColor="rgba(251,113,133,0.1)" circleColor="#fb7185" textColor="#fb7185" />
-          </Card>
+          <div class="kpi-card">
+            <span class="kpi-label">Avg Progress</span>
+            <span class="kpi-value">{{ loading ? '—' : avgProgress + '%' }}</span>
+            <span class="kpi-badge kpi-badge--green">{{ totales.total_proyectos }} projects</span>
+          </div>
+          <div class="kpi-card">
+            <span class="kpi-label">Active Projects</span>
+            <span class="kpi-value">{{ loading ? '—' : totales.proyectos_activos }}</span>
+            <span class="kpi-badge kpi-badge--green">of {{ totales.total_proyectos }} total</span>
+          </div>
+          <div class="kpi-card">
+            <span class="kpi-label">Completed</span>
+            <span class="kpi-value">{{ loading ? '—' : totales.proyectos_completados }}</span>
+            <span class="kpi-badge kpi-badge--purple">{{ completionRate }}% rate</span>
+          </div>
+          <div class="kpi-card">
+            <span class="kpi-label">Budget Total</span>
+            <span class="kpi-value">{{ loading ? '—' : formatBudget(totales.presupuesto_total) }}</span>
+            <span class="kpi-badge" :class="budgetBadgeClass">{{ budgetPct }}% used</span>
+          </div>
         </div>
 
-        <!-- Active Reports Table -->
+        <!-- Projects Overview Table -->
         <div class="section-block">
           <div class="section-header">
-            <span class="section-title">Active Reports</span>
-            <button class="view-all-btn">View all reports →</button>
+            <span class="section-title">Projects Overview</span>
           </div>
 
           <div v-if="loading" class="table-skeleton">
@@ -92,7 +85,7 @@
               <div class="skel-cell" style="width:20%"></div>
               <div class="skel-cell" style="width:15%"></div>
               <div class="skel-cell" style="width:20%"></div>
-              <div class="skel-cell" style="width:15%"></div>
+              
             </div>
           </div>
 
@@ -100,11 +93,11 @@
             <table class="rep-table">
               <thead>
                 <tr>
-                  <th>Report Name</th>
-                  <th>Project</th>
+                  <th>Project Name</th>
+                  <th>Progress</th>
                   <th>Status</th>
-                  <th>Date</th>
-                  <th>Action</th>
+                  <th>Start Date</th>
+                  
                 </tr>
               </thead>
               <tbody>
@@ -116,7 +109,10 @@
                 >
                   <td class="td-name">{{ project.nombre }}</td>
                   <td class="td-project">
-                    <span class="proj-badge">{{ project.nombre }}</span>
+                    <div class="progress-cell">
+                      <div class="prog-track"><div class="prog-fill" :style="{ width: project.progreso_actual + '%' }"></div></div>
+                      <span class="prog-pct">{{ project.progreso_actual }}%</span>
+                    </div>
                   </td>
                   <td class="td-status">
                     <span class="status-tag" :style="{
@@ -128,14 +124,60 @@
                     </span>
                   </td>
                   <td class="td-date">{{ formatDate(project.fecha_inicio) }}</td>
-                  <td class="td-action">
-                    <button class="open-btn" @click.stop="goToDetail(project.id_proyecto)">
-                      Open →
-                    </button>
-                  </td>
+                  
                 </tr>
                 <tr v-if="displayedProjects.length === 0">
                   <td colspan="5" class="empty-row">No projects found.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- Manual Reports Table -->
+        <div class="section-block">
+          <div class="section-header">
+            <span class="section-title">Reports</span>
+            <span class="section-count">{{ reports.length }} report{{ reports.length !== 1 ? 's' : '' }}</span>
+          </div>
+
+          <div v-if="loadingReports" class="table-skeleton">
+            <div v-for="n in 3" :key="n" class="table-skel-row">
+              <div class="skel-cell" style="width:35%"></div>
+              <div class="skel-cell" style="width:15%"></div>
+              <div class="skel-cell" style="width:25%"></div>
+              
+            </div>
+          </div>
+
+          <div v-else class="rep-table-wrap">
+            <table class="rep-table">
+              <thead>
+                <tr>
+                  <th>Title</th>
+                  <th>Type</th>
+                  <th>Project</th>
+                  <th>Date</th>
+                  
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="r in reports"
+                  :key="r.id_reporte"
+                  class="rep-row"
+                  @click="openReportDetail(r)"
+                >
+                  <td class="td-name">{{ r.titulo }}</td>
+                  <td><span class="type-tag">{{ r.tipo }}</span></td>
+                  <td class="td-project">
+                    <span class="proj-badge">{{ projectNameById(r.id_proyecto) }}</span>
+                  </td>
+                  <td class="td-date">{{ formatDate(r.fecha_generacion) }}</td>
+                  
+                </tr>
+                <tr v-if="reports.length === 0">
+                  <td colspan="5" class="empty-row">No reports created yet.</td>
                 </tr>
               </tbody>
             </table>
@@ -147,13 +189,12 @@
           <div class="section-header">
             <span class="section-title">Project Performance</span>
             <div class="chart-legend">
-              <span class="legend-item"><span class="leg-dot gold"></span> Budget</span>
-              <span class="legend-item"><span class="leg-dot blue"></span> Progress</span>
+              <span class="legend-item"><span class="leg-dot gold"></span> Budget used %</span>
+              <span class="legend-item"><span class="leg-dot blue"></span> Progress %</span>
             </div>
           </div>
 
           <div class="chart-wrap">
-            <!-- Y axis labels -->
             <div class="y-axis">
               <span>100</span><span>75</span><span>50</span><span>25</span><span>0</span>
             </div>
@@ -169,31 +210,23 @@
                     <stop offset="100%" stop-color="#60a5fa" stop-opacity="0"/>
                   </linearGradient>
                 </defs>
-                <!-- Grid lines -->
-                <line x1="0" y1="0" x2="600" y2="0" stroke="#1f1f1f" stroke-width="1"/>
-                <line x1="0" y1="40" x2="600" y2="40" stroke="#1f1f1f" stroke-width="1"/>
-                <line x1="0" y1="80" x2="600" y2="80" stroke="#1f1f1f" stroke-width="1"/>
+                <line x1="0" y1="0"   x2="600" y2="0"   stroke="#1f1f1f" stroke-width="1"/>
+                <line x1="0" y1="40"  x2="600" y2="40"  stroke="#1f1f1f" stroke-width="1"/>
+                <line x1="0" y1="80"  x2="600" y2="80"  stroke="#1f1f1f" stroke-width="1"/>
                 <line x1="0" y1="120" x2="600" y2="120" stroke="#1f1f1f" stroke-width="1"/>
                 <line x1="0" y1="160" x2="600" y2="160" stroke="#1f1f1f" stroke-width="1"/>
-                <!-- Gold area -->
-                <path d="M0,140 C60,120 120,100 180,80 C240,60 300,50 360,40 C420,30 480,20 600,15 L600,160 L0,160 Z" fill="url(#lineGrad)"/>
-                <!-- Gold line -->
-                <path d="M0,140 C60,120 120,100 180,80 C240,60 300,50 360,40 C420,30 480,20 600,15" fill="none" stroke="#c9a962" stroke-width="2"/>
-                <!-- Blue area -->
-                <path d="M0,155 C60,150 120,140 180,130 C240,120 300,105 360,90 C420,75 480,60 600,45 L600,160 L0,160 Z" fill="url(#lineGrad2)"/>
-                <!-- Blue line -->
-                <path d="M0,155 C60,150 120,140 180,130 C240,120 300,105 360,90 C420,75 480,60 600,45" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="4 3"/>
-                <!-- Dots on gold line -->
-                <circle cx="0" cy="140" r="3" fill="#c9a962"/>
-                <circle cx="120" cy="100" r="3" fill="#c9a962"/>
-                <circle cx="240" cy="60" r="3" fill="#c9a962"/>
-                <circle cx="360" cy="40" r="3" fill="#c9a962"/>
-                <circle cx="480" cy="20" r="3" fill="#c9a962"/>
-                <circle cx="600" cy="15" r="3" fill="#c9a962"/>
+                <template v-if="chartPoints.length">
+                  <path :d="svgAreaPath(chartPoints, 'budgetY')"   fill="url(#lineGrad)"/>
+                  <path :d="svgLinePath(chartPoints, 'budgetY')"   fill="none" stroke="#c9a962" stroke-width="2"/>
+                  <path :d="svgAreaPath(chartPoints, 'progressY')" fill="url(#lineGrad2)"/>
+                  <path :d="svgLinePath(chartPoints, 'progressY')" fill="none" stroke="#60a5fa" stroke-width="1.5" stroke-dasharray="4 3"/>
+                  <circle v-for="pt in chartPoints" :key="pt.x + '-b'" :cx="pt.x" :cy="pt.budgetY"   r="3" fill="#c9a962"/>
+                  <circle v-for="pt in chartPoints" :key="pt.x + '-p'" :cx="pt.x" :cy="pt.progressY" r="3" fill="#60a5fa"/>
+                </template>
+                <text v-else x="300" y="88" text-anchor="middle" fill="#333" font-size="11" font-family="Manrope, sans-serif">No data</text>
               </svg>
               <div class="x-axis">
-                <span>Jan</span><span>Feb</span><span>Mar</span>
-                <span>Apr</span><span>May</span><span>Jun</span>
+                <span v-for="pt in chartPoints" :key="pt.x" :title="pt.name">{{ truncName(pt.name) }}</span>
               </div>
             </div>
           </div>
@@ -245,16 +278,16 @@
           <p class="ctx-label">Budget Usage</p>
           <div class="donut-wrap">
             <DonutChart
-              :pct="72"
+              :pct="budgetPct"
               color="#c9a962"
               :size="80" :radius="30" :stroke-width="10"
-              label="72%" label-color="#fff" :label-font-size="13" :label-offset-y="4"
+              :label="budgetPct + '%'" label-color="#fff" :label-font-size="13" :label-offset-y="4"
               display-width="90px"
             />
           </div>
           <div class="donut-legend">
-            <span class="dl-item"><span class="dl-dot gold"></span>Used (72%)</span>
-            <span class="dl-item"><span class="dl-dot dim"></span>Remaining (28%)</span>
+            <span class="dl-item"><span class="dl-dot gold"></span>Used ({{ budgetPct }}%)</span>
+            <span class="dl-item"><span class="dl-dot dim"></span>Remaining ({{ 100 - budgetPct }}%)</span>
           </div>
         </div>
 
@@ -265,16 +298,16 @@
           <p class="ctx-label">Task Completion</p>
           <div class="bar-list">
             <div class="bar-item">
-              <div class="bar-track"><div class="bar-fill gold" style="width:75%"></div></div>
-              <span class="bar-val">245</span>
+              <div class="bar-track"><div class="bar-fill gold" :style="{ width: barPct(taskStats.completadas) }"></div></div>
+              <span class="bar-val">{{ taskStats.completadas }}</span>
             </div>
             <div class="bar-item">
-              <div class="bar-track"><div class="bar-fill blue" style="width:30%"></div></div>
-              <span class="bar-val">42</span>
+              <div class="bar-track"><div class="bar-fill blue" :style="{ width: barPct(taskStats.enProgreso) }"></div></div>
+              <span class="bar-val">{{ taskStats.enProgreso }}</span>
             </div>
             <div class="bar-item">
-              <div class="bar-track"><div class="bar-fill dim" style="width:18%"></div></div>
-              <span class="bar-val">18</span>
+              <div class="bar-track"><div class="bar-fill dim" :style="{ width: barPct(taskStats.pendientes) }"></div></div>
+              <span class="bar-val">{{ taskStats.pendientes }}</span>
             </div>
           </div>
           <div class="bar-labels">
@@ -286,6 +319,91 @@
 
       </aside>
     </div>
+
+    <!-- ── REPORT DETAIL MODAL ──────────────────────────────── -->
+    <div v-if="reportDetail" class="modal-overlay" @click.self="reportDetail = null">
+      <div class="modal-box">
+        <div class="modal-header">
+          <span class="modal-title">{{ reportDetail.titulo }}</span>
+          <button class="modal-close" @click="reportDetail = null">✕</button>
+        </div>
+        <div class="rdetail-body">
+          <div class="rdetail-row">
+            <span class="rdetail-label">Type</span>
+            <span class="type-tag">{{ reportDetail.tipo }}</span>
+          </div>
+          <div class="rdetail-row">
+            <span class="rdetail-label">Project</span>
+            <span class="rdetail-val">{{ projectNameById(reportDetail.id_proyecto) }}</span>
+          </div>
+          <div class="rdetail-row">
+            <span class="rdetail-label">Date</span>
+            <span class="rdetail-val">{{ formatDate(reportDetail.fecha_generacion) }}</span>
+          </div>
+          <div v-if="reportDetail.contenido_url" class="rdetail-row">
+            <span class="rdetail-label">Content URL</span>
+            <a :href="reportDetail.contenido_url" target="_blank" rel="noopener" class="rdetail-link">
+              Open document →
+            </a>
+          </div>
+          <div v-else class="rdetail-row">
+            <span class="rdetail-label">Content URL</span>
+            <span class="rdetail-val dim">Not provided</span>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn-outline" @click="reportDetail = null">Close</button>
+          <button class="btn-outline" @click="goToDetail(reportDetail.id_proyecto); reportDetail = null">
+            View Project Metrics →
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── CREATE REPORT MODAL ──────────────────────────────── -->
+    <div v-if="showCreateModal" class="modal-overlay" @click.self="closeCreateModal">
+      <div class="modal-box">
+        <div class="modal-header">
+          <span class="modal-title">New Report</span>
+          <button class="modal-close" @click="closeCreateModal">✕</button>
+        </div>
+        <form class="modal-form" @submit.prevent="submitCreate">
+          <div class="form-group">
+            <label class="form-label">Title</label>
+            <input v-model="createForm.titulo" class="form-input" placeholder="Report title" required maxlength="200" />
+          </div>
+          <div class="form-group">
+            <label class="form-label">Type</label>
+            <select v-model="createForm.tipo" class="form-input" required>
+              <option value="">Select type…</option>
+              <option value="AVANCE">Progress</option>
+              <option value="PRESUPUESTO">Budget</option>
+              <option value="INCIDENTE">Incident</option>
+              <option value="CONSOLIDADO">Consolidated</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Project</label>
+            <select v-model="createForm.id_proyecto" class="form-input" required>
+              <option value="">Select project…</option>
+              <option v-for="p in summary.proyectos" :key="p.id_proyecto" :value="p.id_proyecto">{{ p.nombre }}</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Content URL <span class="form-optional">(optional)</span></label>
+            <input v-model="createForm.contenido_url" class="form-input" placeholder="https://…" type="url" />
+          </div>
+          <p v-if="createError" class="form-error">{{ createError }}</p>
+          <div class="modal-footer">
+            <button type="button" class="btn-outline" @click="closeCreateModal">Cancel</button>
+            <button type="submit" class="btn-primary" :disabled="creating">
+              {{ creating ? 'Creating…' : 'Create Report' }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+
   </div>
 </template>
 
@@ -293,21 +411,28 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import AppNavbar  from '../components/AppNavbar.vue'
-import Card       from '../components/UI/Card/Card.vue'
-import Pill       from '../components/UI/Pill/Pill.vue'
 import Button     from '../components/UI/Button/Button.vue'
 import DonutChart from '../components/UI/DonutChart/DonutChart.vue'
 import { statusPill, formatDate, formatBudget } from '../utils/statusHelpers.js'
 import { useAuthStore } from '../stores/auth'
 
-const router   = useRouter()
+const router    = useRouter()
 const authStore = useAuthStore()
 
-const projects   = ref([])
+const summary    = ref({ totales: null, proyectos: [] })
 const loading    = ref(true)
 const fetchError = ref(null)
 const activeFilter = ref('all')
 const aiEnabled    = ref(true)
+
+const reports        = ref([])
+const loadingReports = ref(true)
+const reportDetail   = ref(null)
+
+const showCreateModal = ref(false)
+const creating        = ref(false)
+const createError     = ref(null)
+const createForm      = ref({ titulo: '', tipo: '', id_proyecto: '', contenido_url: '' })
 
 const filters = [
   { key: 'all',       label: 'All Projects' },
@@ -317,20 +442,21 @@ const filters = [
 ]
 
 // ── API ────────────────────────────────────────────────────────────────────
-function authHeader() {
-  return { Authorization: `Bearer ${authStore.token}` }
+function authHeaders() {
+  return {
+    Authorization: `Bearer ${authStore.token}`,
+    'X-Company-ID': String(authStore.idEmpresa),
+  }
 }
 
-async function loadProjects() {
+async function loadSummary() {
   loading.value = true
   fetchError.value = null
   try {
-    const params = new URLSearchParams({ page: 1, limit: 50 })
-    if (authStore.idEmpresa) params.set('id_empresa', authStore.idEmpresa)
-    const res = await fetch(`/api/projects?${params}`, { headers: authHeader() })
+    const res = await fetch('/api/reports/summary', { headers: authHeaders() })
     if (!res.ok) throw new Error(`Error ${res.status}`)
     const json = await res.json()
-    projects.value = json.data ?? []
+    summary.value = json.data ?? { totales: null, proyectos: [] }
   } catch (e) {
     fetchError.value = e.message
   } finally {
@@ -338,35 +464,166 @@ async function loadProjects() {
   }
 }
 
-onMounted(loadProjects)
+async function loadReports() {
+  loadingReports.value = true
+  try {
+    const res = await fetch('/api/reports', { headers: authHeaders() })
+    if (!res.ok) throw new Error()
+    reports.value = (await res.json()).data ?? []
+  } catch {
+    reports.value = []
+  } finally {
+    loadingReports.value = false
+  }
+}
+
+onMounted(() => {
+  loadSummary()
+  loadReports()
+})
 
 // ── Computed ───────────────────────────────────────────────────────────────
 const displayedProjects = computed(() => {
-  if (activeFilter.value === 'active') {
-    return projects.value.filter(p => p.estado === 'EN_PROGRESO' || p.estado === 'PLANIFICADO' || p.estado === 'PAUSADO')
-  }
-  if (activeFilter.value === 'completed') {
-    return projects.value.filter(p => p.estado === 'COMPLETADO')
-  }
+  const list = summary.value.proyectos
+  if (activeFilter.value === 'active')
+    return list.filter(p => p.estado === 'EN_PROGRESO' || p.estado === 'PLANIFICADO' || p.estado === 'PAUSADO')
+  if (activeFilter.value === 'completed')
+    return list.filter(p => p.estado === 'COMPLETADO')
   if (activeFilter.value === 'last30') {
     const cutoff = new Date()
     cutoff.setDate(cutoff.getDate() - 30)
-    return projects.value.filter(p => new Date(p.fecha_inicio) >= cutoff)
+    return list.filter(p => new Date(p.fecha_inicio) >= cutoff)
   }
-  return projects.value
+  return list
 })
 
-const completedCount = computed(() =>
-  projects.value.filter(p => p.estado === 'COMPLETADO').length
+const totales = computed(() => summary.value.totales ?? {
+  total_proyectos: 0,
+  proyectos_activos: 0,
+  proyectos_completados: 0,
+  presupuesto_total: 0,
+})
+
+const avgProgress = computed(() => {
+  const list = summary.value.proyectos
+  if (!list.length) return 0
+  return Math.round(list.reduce((acc, p) => acc + Number(p.progreso_actual), 0) / list.length)
+})
+
+const budgetPct = computed(() => {
+  const list = summary.value.proyectos
+  const planificado = list.reduce((s, p) => s + Number(p.presupuesto_planificado), 0)
+  const real = list.reduce((s, p) => s + Number(p.presupuesto_real), 0)
+  if (!planificado) return 0
+  return Math.min(Math.round((real / planificado) * 100), 100)
+})
+
+const taskStats = computed(() => {
+  const list = summary.value.proyectos
+  const total       = list.reduce((s, p) => s + Number(p.total_tareas), 0)
+  const completadas = list.reduce((s, p) => s + Number(p.tareas_completadas), 0)
+  const enProgreso  = list.reduce((s, p) => s + Number(p.tareas_en_progreso), 0)
+  const pendientes  = list.reduce((s, p) => s + Number(p.tareas_pendientes), 0)
+  return { total, completadas, enProgreso, pendientes }
+})
+
+const completionRate = computed(() => {
+  const t = totales.value.total_proyectos
+  if (!t) return 0
+  return Math.round((totales.value.proyectos_completados / t) * 100)
+})
+
+const budgetBadgeClass = computed(() =>
+  budgetPct.value > 90 ? 'kpi-badge--red' : budgetPct.value > 70 ? 'kpi-badge--purple' : 'kpi-badge--green'
 )
 
-const totalBudget = computed(() =>
-  projects.value.reduce((sum, p) => sum + (parseFloat(p.presupuesto_total) || 0), 0)
-)
-
+function barPct(n) {
+  return taskStats.value.total ? Math.round((n / taskStats.value.total) * 100) + '%' : '0%'
+}
 
 function goToDetail(id) {
   router.push({ name: 'report-detail', params: { id } })
+}
+
+const chartPoints = computed(() => {
+  const list = summary.value.proyectos
+  if (!list.length) return []
+  const n = list.length
+  return list.map((p, i) => {
+    const x = n === 1 ? 300 : Math.round((i / (n - 1)) * 600)
+    const bTotal = Number(p.presupuesto_total)
+    const bReal  = Number(p.presupuesto_real)
+    const bPct   = bTotal > 0 ? Math.min(Math.round((bReal / bTotal) * 100), 100) : 0
+    const prog  = Number(p.progreso_actual)
+    return {
+      x,
+      budgetY:   Math.round(155 - (bPct / 100) * 150),
+      progressY: Math.round(155 - (prog / 100) * 150),
+      name: p.nombre,
+      budgetPct:   bPct,
+      progressPct: prog,
+    }
+  })
+})
+
+function svgLinePath(pts, yKey) {
+  return pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p[yKey]}`).join(' ')
+}
+
+function svgAreaPath(pts, yKey) {
+  const line = svgLinePath(pts, yKey)
+  return `${line} L${pts[pts.length - 1].x},160 L${pts[0].x},160 Z`
+}
+
+function truncName(name) {
+  return name.length > 13 ? name.slice(0, 12) + '…' : name
+}
+
+function projectNameById(id) {
+  return summary.value.proyectos.find(p => p.id_proyecto === id)?.nombre ?? '—'
+}
+
+function openReportDetail(r) {
+  reportDetail.value = r
+}
+
+function openCreateModal() {
+  createForm.value = { titulo: '', tipo: '', id_proyecto: '', contenido_url: '' }
+  createError.value = null
+  showCreateModal.value = true
+}
+
+function closeCreateModal() {
+  showCreateModal.value = false
+}
+
+async function submitCreate() {
+  creating.value = true
+  createError.value = null
+  try {
+    const body = {
+      titulo: createForm.value.titulo,
+      tipo: createForm.value.tipo,
+      id_proyecto: Number(createForm.value.id_proyecto),
+    }
+    if (createForm.value.contenido_url) body.contenido_url = createForm.value.contenido_url
+    const res = await fetch('/api/reports', {
+      method: 'POST',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (!res.ok) {
+      const err = await res.json()
+      createError.value = err.message ?? 'Failed to create report.'
+      return
+    }
+    closeCreateModal()
+    await Promise.all([loadSummary(), loadReports()])
+  } catch {
+    createError.value = 'Network error.'
+  } finally {
+    creating.value = false
+  }
 }
 </script>
 
@@ -452,34 +709,31 @@ function goToDetail(id) {
 /* ─── Filters ────────────────────────────────────────────────────────────── */
 .filter-bar {
   display: flex;
-  gap: 6px;
+  gap: 24px;
   margin-bottom: 24px;
+  border-bottom: 1px solid #1a1a1a;
   flex-wrap: wrap;
 }
 
 .filter-btn {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 14px;
-  background: rgba(255,255,255,0.03);
-  border: 1px solid #1e1e1e;
-  color: #666;
+  padding: 6px 0;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: #555;
   font-family: 'Manrope', sans-serif;
   font-size: 12px;
+  font-weight: 600;
   cursor: pointer;
-  transition: all .2s;
+  transition: color .2s, border-color .2s;
 }
 
-.filter-btn:hover { border-color: rgba(255,255,255,0.15); color: #aaa; }
+.filter-btn:hover { color: #aaa; }
 
 .filter-btn.active {
-  background: rgba(201,169,98,0.1);
-  border-color: rgba(201,169,98,0.4);
+  border-bottom-color: #c9a962;
   color: #c9a962;
 }
-
-.chevron { opacity: 0.5; }
 
 /* ─── KPI Cards ──────────────────────────────────────────────────────────── */
 .kpi-grid {
@@ -489,35 +743,50 @@ function goToDetail(id) {
   margin-bottom: 28px;
 }
 
-.kpi-grid :deep(.card) {
-  max-width: none;
-  width: 100%;
-  margin: 0;
-  border-radius: 0;
+.kpi-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
   padding: 16px;
-  gap: 10px;
-  transition: border-color .2s, background .2s;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid #1e1e1e;
+  transition: border-color .2s;
 }
 
-.kpi-grid :deep(.card:hover) {
-  border-color: rgba(201,169,98,0.3) !important;
+.kpi-card:hover {
+  border-color: rgba(201,169,98,0.3);
 }
 
-.kpi-grid :deep(.card-title) {
+.kpi-label {
+  font-family: 'Manrope', sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  color: #555;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.kpi-value {
   font-family: 'Playfair Display', serif;
-  font-size: 1.6rem;
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #faf8f5;
   line-height: 1;
 }
 
-.kpi-grid :deep(.card-subtitle) {
-  font-size: 11px;
-  color: var(--TextMuted);
+.kpi-badge {
+  display: inline-block;
+  padding: 3px 10px;
   font-family: 'Manrope', sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  border-radius: 2px;
+  width: fit-content;
 }
 
-.kpi-grid :deep(.pill) {
-  margin-top: 4px;
-}
+.kpi-badge--green  { background: rgba(74,222,128,0.1);  color: #4ade80; }
+.kpi-badge--purple { background: rgba(167,139,250,0.1); color: #a78bfa; }
+.kpi-badge--red    { background: rgba(251,113,133,0.1); color: #fb7185; }
 
 /* ─── Section blocks ─────────────────────────────────────────────────────── */
 .section-block {
@@ -618,6 +887,27 @@ function goToDetail(id) {
 }
 
 .td-date { color: #555; font-size: 11px; }
+
+.progress-cell { display: flex; align-items: center; gap: 7px; }
+.prog-track { flex: 1; height: 4px; background: #1a1a1a; border-radius: 2px; overflow: hidden; min-width: 60px; }
+.prog-fill  { height: 100%; background: linear-gradient(90deg, #b27f2a, #c9a962); border-radius: 2px; }
+.prog-pct   { font-family: 'Manrope', sans-serif; font-size: 10px; color: #666; min-width: 30px; }
+
+.type-tag {
+  font-family: 'Manrope', sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  color: #a78bfa;
+  background: rgba(167,139,250,0.08);
+  padding: 2px 7px;
+  letter-spacing: 0.04em;
+}
+
+.section-count {
+  font-family: 'Manrope', sans-serif;
+  font-size: 12px;
+  color: #444;
+}
 
 .open-btn {
   background: none;
@@ -900,6 +1190,148 @@ function goToDetail(id) {
   color: #444;
   padding-top: 2px;
 }
+
+/* ─── Create Report Modal ────────────────────────────────────────────────── */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.72);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+}
+
+.modal-box {
+  background: #111;
+  border: 1px solid #2a2a2a;
+  width: 100%;
+  max-width: 440px;
+  padding: 24px;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.modal-title {
+  font-family: 'Manrope', sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  color: #e8e4de;
+  letter-spacing: 0.04em;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  color: #555;
+  font-size: 14px;
+  cursor: pointer;
+  line-height: 1;
+  transition: color .2s;
+}
+.modal-close:hover { color: #ccc; }
+
+.modal-form { display: flex; flex-direction: column; gap: 14px; }
+
+.form-group { display: flex; flex-direction: column; gap: 5px; }
+
+.form-label {
+  font-family: 'Manrope', sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  color: #555;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.form-optional {
+  font-weight: 400;
+  color: #444;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.form-input {
+  padding: 8px 10px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid #2a2a2a;
+  color: #ccc;
+  font-family: 'Manrope', sans-serif;
+  font-size: 12px;
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+  transition: border-color .2s;
+}
+.form-input:focus { border-color: rgba(201,169,98,0.4); }
+.form-input option { background: #111; }
+
+/* ─── Report Detail Modal ────────────────────────────────────────────────── */
+.rdetail-body { display: flex; flex-direction: column; gap: 0; margin-bottom: 20px; }
+.rdetail-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid #1a1a1a;
+}
+.rdetail-label {
+  font-family: 'Manrope', sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  color: #555;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.rdetail-val {
+  font-family: 'Manrope', sans-serif;
+  font-size: 12px;
+  color: #aaa;
+}
+.rdetail-val.dim { color: #444; }
+.rdetail-link {
+  font-family: 'Manrope', sans-serif;
+  font-size: 12px;
+  color: #c9a962;
+  text-decoration: none;
+  transition: opacity .2s;
+}
+.rdetail-link:hover { opacity: 0.7; }
+
+.form-error {
+  font-family: 'Manrope', sans-serif;
+  font-size: 11px;
+  color: #fb7185;
+  margin: 0;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.btn-primary {
+  display: flex;
+  align-items: center;
+  padding: 8px 16px;
+  background: rgba(201,169,98,0.12);
+  border: 1px solid rgba(201,169,98,0.3);
+  color: #c9a962;
+  font-family: 'Manrope', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background .2s;
+}
+.btn-primary:hover:not(:disabled) { background: rgba(201,169,98,0.22); }
+.btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 
 /* ─── Responsive ─────────────────────────────────────────────────────────── */
 @media (max-width: 1100px) {


### PR DESCRIPTION
## Summary
Replace hardcoded/mock data in the reports module with real API data. `ReportsView` now consumes `/api/reports/summary` for KPIs, project overview table, performance chart (budget % vs progress %), and a separate section for manually created reports. `ReportDetailView` uses `/api/projects/:id/metrics` for tasks by state, budget, and team data. The `getCompanySummary` query was extended to include task counts by state (`EN_PROGRESO`, `PENDIENTE`).

## Type of change
- [x] `feat` – new feature
- [x] `refactor` – code change that is neither a fix nor a feature

## Related issue / task
Task T-31

## Testing
- [x] Tested manually (Postman / browser)
- [ ] Unit tests pass
- [x] No regressions on existing endpoints

## Checklist
- [x] Branch follows naming convention (`feat/reports-logic`)
- [x] Commits follow Conventional Commits (`type(scope): message`)
- [x] No secrets or credentials committed
- [x] `password_hash` or sensitive fields are not exposed in responses
- [ ] `.env.example` updated if new env vars were added
