### PR TITLE
feat: unit tests del punto de venta (POS)

### DIFF
--- a/frontend/src/utils/sales.js
+++ b/frontend/src/utils/sales.js
@@ -1,0 +1,120 @@
+/**
+ * Lógica de cálculo del punto de venta (POS).
+ *
+ * Funciones puras, sin dependencias de Vue ni de red, para poder probarlas de
+ * forma aislada. Aquí vive el cálculo con mayor riesgo financiero del sistema:
+ * subtotales, descuentos, IVA y total de una venta. El orden de operaciones es
+ * siempre: subtotal → descuento → impuesto.
+ */
+
+/** IVA vigente en Guatemala (12%). */
+export const IVA_RATE = 0.12
+
+/**
+ * Redondea a dos decimales evitando los errores clásicos de coma flotante
+ * (p. ej. 1.005 → 1.01). Los valores no numéricos se tratan como 0.
+ */
+export function round2(value) {
+  const n = Number(value)
+  if (!Number.isFinite(n)) return 0
+  return Math.round((n + Number.EPSILON) * 100) / 100
+}
+
+/**
+ * Valida y normaliza el precio de un producto.
+ * Un precio nulo, vacío o no numérico produce un error controlado (nunca NaN).
+ */
+function toPrice(precio) {
+  if (precio === null || precio === undefined || precio === '') {
+    throw new Error('El producto no tiene precio.')
+  }
+  const n = Number(precio)
+  if (!Number.isFinite(n)) {
+    throw new Error('El precio del producto no es un número válido.')
+  }
+  if (n < 0) {
+    throw new Error('El precio del producto no puede ser negativo.')
+  }
+  return n
+}
+
+/**
+ * Valida y normaliza la cantidad de una línea.
+ * La cantidad 0 es válida (no suma al total); una cantidad negativa se rechaza.
+ */
+function toQuantity(cantidad) {
+  const n = Number(cantidad)
+  if (!Number.isFinite(n)) {
+    throw new Error('La cantidad no es un número válido.')
+  }
+  if (n < 0) {
+    throw new Error('La cantidad no puede ser negativa.')
+  }
+  return n
+}
+
+/**
+ * Normaliza un porcentaje (descuento o tasa) al rango [0, 100].
+ * Valores inválidos o negativos se tratan como 0.
+ */
+function clampPercent(percent) {
+  const n = Number(percent)
+  if (!Number.isFinite(n) || n < 0) return 0
+  if (n > 100) return 100
+  return n
+}
+
+/**
+ * Subtotal de una línea de venta (precio × cantidad), redondeado a 2 decimales.
+ * Acepta `{ precio, cantidad }` o un ítem del carrito `{ product, cantidad }`.
+ */
+export function lineTotal(line) {
+  const precio = toPrice(line?.precio ?? line?.precio_venta ?? line?.product?.precio_venta)
+  const cantidad = toQuantity(line?.cantidad)
+  return round2(precio * cantidad)
+}
+
+/**
+ * Suma de los subtotales de todas las líneas. Una venta vacía devuelve 0.
+ */
+export function calcSubtotal(lines) {
+  if (!Array.isArray(lines) || lines.length === 0) return 0
+  const sum = lines.reduce((acc, line) => acc + lineTotal(line), 0)
+  return round2(sum)
+}
+
+/**
+ * Aplica un descuento porcentual a un monto. El porcentaje se limita a [0, 100],
+ * por lo que un 100% deja el monto en 0 y el resultado nunca es negativo.
+ */
+export function applyDiscount(amount, discountPercent = 0) {
+  const base = round2(amount)
+  const pct = clampPercent(discountPercent)
+  return round2(Math.max(base * (1 - pct / 100), 0))
+}
+
+/**
+ * Calcula el desglose completo de una venta.
+ *
+ * Orden de operaciones (garantizado): el descuento se aplica sobre el subtotal
+ * y el impuesto se calcula sobre el subtotal ya descontado.
+ *
+ * @param {Array} lines Líneas de la venta (`{ precio, cantidad }`).
+ * @param {object} [options]
+ * @param {number} [options.discountPercent=0] Descuento porcentual [0, 100].
+ * @param {number} [options.taxRate=IVA_RATE] Tasa de impuesto (0.12 = 12%).
+ * @returns {{ subtotal:number, discount:number, taxableBase:number, tax:number, total:number }}
+ */
+export function calcSale(lines, { discountPercent = 0, taxRate = IVA_RATE } = {}) {
+  const subtotal = calcSubtotal(lines)
+
+  const pct = clampPercent(discountPercent)
+  const discount = round2(subtotal * (pct / 100))
+  const taxableBase = round2(Math.max(subtotal - discount, 0))
+
+  const rate = Number.isFinite(Number(taxRate)) && Number(taxRate) > 0 ? Number(taxRate) : 0
+  const tax = round2(taxableBase * rate)
+  const total = round2(Math.max(taxableBase + tax, 0))
+
+  return { subtotal, discount, taxableBase, tax, total }
+}

--- a/frontend/src/views/InventoryPage.vue
+++ b/frontend/src/views/InventoryPage.vue
@@ -384,6 +384,7 @@ import Pill from '../components/UI/Pill/Pill.vue'
 import Button from '../components/UI/Button/Button.vue'
 import ProductModal from '../components/inventory/ProductModal.vue'
 import { useAuthStore } from '@/stores/auth'
+import { lineTotal, calcSubtotal } from '@/utils/sales.js'
 
 const { t } = useI18n()
 const authStore = useAuthStore()
@@ -639,12 +640,10 @@ function clearSaleCart() {
 }
 
 function saleItemSubtotal(item) {
-  return Number(item.product.precio_venta) * Number(item.cantidad)
+  return lineTotal(item)
 }
 
-const saleTotal = computed(() =>
-  saleCart.value.reduce((acc, item) => acc + saleItemSubtotal(item), 0)
-)
+const saleTotal = computed(() => calcSubtotal(saleCart.value))
 
 const canSubmitSale = computed(() => saleCart.value.length > 0)
 

--- a/frontend/tests/sales.test.js
+++ b/frontend/tests/sales.test.js
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import {
+  IVA_RATE,
+  round2,
+  lineTotal,
+  calcSubtotal,
+  applyDiscount,
+  calcSale,
+} from '@/utils/sales.js'
+
+// Lógica del punto de venta (POS): es el cálculo con mayor riesgo financiero
+// del sistema, por eso cada caso de negocio se prueba de forma aislada.
+describe('POS · lógica de ventas', () => {
+  // 1. Total con un producto, cantidad 1.
+  it('calcula el total de un solo producto con cantidad 1', () => {
+    const lines = [{ precio: 100, cantidad: 1 }]
+    expect(calcSubtotal(lines)).toBe(100)
+    expect(calcSale(lines, { taxRate: 0 }).total).toBe(100)
+  })
+
+  // 2. Subtotal con múltiples líneas y cantidades distintas.
+  it('suma subtotales de múltiples líneas con cantidades distintas', () => {
+    const lines = [
+      { precio: 100, cantidad: 2 }, // 200
+      { precio: 55.5, cantidad: 3 }, // 166.5
+      { precio: 10, cantidad: 1 }, //  10
+    ]
+    expect(calcSubtotal(lines)).toBe(376.5)
+  })
+
+  // 3. Descuento porcentual aplicado correctamente.
+  it('aplica un descuento porcentual correctamente', () => {
+    expect(applyDiscount(100, 10)).toBe(90)
+    const { discount, total } = calcSale([{ precio: 100, cantidad: 1 }], {
+      discountPercent: 10,
+      taxRate: 0,
+    })
+    expect(discount).toBe(10)
+    expect(total).toBe(90)
+  })
+
+  // 4. Descuento del 100% → total 0, nunca negativo.
+  it('con descuento del 100% el total es 0 y nunca negativo', () => {
+    expect(applyDiscount(250, 100)).toBe(0)
+    expect(calcSale([{ precio: 250, cantidad: 2 }], { discountPercent: 100 }).total).toBe(0)
+    // Un porcentaje mayor a 100 se limita: sigue siendo 0, jamás negativo.
+    expect(applyDiscount(250, 150)).toBe(0)
+    expect(calcSale([{ precio: 250, cantidad: 2 }], { discountPercent: 150 }).total).toBe(0)
+  })
+
+  // 5. Cálculo de IVA (12%) sobre el subtotal ya descontado.
+  it('calcula el IVA (12%) sobre el subtotal ya descontado', () => {
+    // Sin descuento: 100 + 12% = 112.
+    const sinDescuento = calcSale([{ precio: 100, cantidad: 1 }], { taxRate: IVA_RATE })
+    expect(sinDescuento.tax).toBe(12)
+    expect(sinDescuento.total).toBe(112)
+
+    // Con 10% de descuento: base gravable 90, IVA 10.8, total 100.8.
+    const conDescuento = calcSale([{ precio: 100, cantidad: 1 }], {
+      discountPercent: 10,
+      taxRate: IVA_RATE,
+    })
+    expect(conDescuento.taxableBase).toBe(90)
+    expect(conDescuento.tax).toBe(10.8)
+    expect(conDescuento.total).toBe(100.8)
+  })
+
+  // 6. Orden de operaciones: descuento antes de impuesto.
+  it('aplica el descuento antes del impuesto', () => {
+    const { subtotal, discount, taxableBase, tax, total } = calcSale(
+      [{ precio: 200, cantidad: 1 }],
+      { discountPercent: 50, taxRate: IVA_RATE }
+    )
+    expect(subtotal).toBe(200)
+    expect(discount).toBe(100)
+    // El impuesto se calcula sobre la base ya descontada, no sobre el subtotal.
+    expect(taxableBase).toBe(subtotal - discount) // 100
+    expect(tax).toBe(round2(taxableBase * IVA_RATE)) // 12
+    // Si el IVA se aplicara antes del descuento, tax sería 24: se descarta.
+    expect(tax).not.toBe(round2(subtotal * IVA_RATE))
+    expect(total).toBe(112)
+  })
+
+  // 7. Cantidad cero → la línea no suma al total.
+  it('una línea con cantidad cero no suma al total', () => {
+    expect(lineTotal({ precio: 100, cantidad: 0 })).toBe(0)
+    const lines = [
+      { precio: 100, cantidad: 0 },
+      { precio: 50, cantidad: 2 },
+    ]
+    expect(calcSubtotal(lines)).toBe(100)
+  })
+
+  // 8. Producto sin precio o null → error controlado, no NaN.
+  it('rechaza un producto sin precio con error controlado (no NaN)', () => {
+    expect(() => lineTotal({ precio: null, cantidad: 1 })).toThrow()
+    expect(() => lineTotal({ precio: undefined, cantidad: 1 })).toThrow()
+    expect(() => lineTotal({ precio: 'abc', cantidad: 1 })).toThrow()
+    expect(() => lineTotal({ precio: -5, cantidad: 1 })).toThrow()
+    expect(() => calcSubtotal([{ precio: null, cantidad: 1 }])).toThrow()
+  })
+
+  // 9. Redondeo a dos decimales.
+  it('redondea el resultado a dos decimales', () => {
+    expect(round2(1.005)).toBe(1.01)
+    expect(round2(2.675)).toBe(2.68)
+    // 10.10 + 12% IVA = 11.312 → 11.31.
+    expect(calcSale([{ precio: 10.1, cantidad: 1 }], { taxRate: IVA_RATE }).total).toBe(11.31)
+    expect(lineTotal({ precio: 33.333, cantidad: 3 })).toBe(100)
+  })
+
+  // 10. Venta vacía → total 0.
+  it('una venta vacía tiene total 0', () => {
+    expect(calcSubtotal([])).toBe(0)
+    expect(calcSale([]).total).toBe(0)
+    expect(calcSubtotal(null)).toBe(0)
+  })
+
+  // 11. Cantidad negativa → rechazo por validación.
+  it('rechaza cantidades negativas por validación', () => {
+    expect(() => lineTotal({ precio: 100, cantidad: -1 })).toThrow()
+    expect(() => lineTotal({ precio: 100, cantidad: 'x' })).toThrow()
+    expect(() => calcSubtotal([{ precio: 100, cantidad: -2 }])).toThrow()
+  })
+})


### PR DESCRIPTION
## Objetivo

Automatizar los unit tests de la lógica del **punto de venta (POS)** — el cálculo con mayor riesgo financiero del sistema y el módulo más reciente (Sprint 4), por lo tanto el menos ejercitado.

## Cambios

- **`frontend/src/utils/sales.js`** (nuevo): extrae la lógica de ventas del POS a un módulo puro y testeable, siguiendo el patrón de los demás módulos (`utils/*.js` + tests con vitest). Centraliza:
  - `lineTotal` / `calcSubtotal` — subtotales por línea y de la venta.
  - `applyDiscount` — descuento porcentual acotado a `[0, 100]`.
  - `calcSale` — desglose completo (`subtotal → descuento → base gravable → IVA → total`). El **descuento se aplica antes del impuesto** y el total **nunca es negativo**.
  - `round2` — redondeo a dos decimales sin errores de coma flotante.
  - Validaciones: precio nulo/no numérico y cantidad negativa producen **error controlado (nunca NaN)**.
- **`InventoryPage.vue`**: el carrito de venta ahora usa `lineTotal` / `calcSubtotal` del módulo (misma salida visible, una sola fuente de verdad).
- **`frontend/tests/sales.test.js`** (nuevo): **vitest**, mismo estilo que los tests existentes.

## Casos automatizados (11 / 11 ✅)

1. Total con un producto, cantidad 1
2. Subtotal con múltiples líneas y cantidades distintas
3. Descuento porcentual aplicado correctamente
4. Descuento del 100% → total 0, nunca negativo
5. IVA (12%) sobre el subtotal ya descontado
6. Orden de operaciones: descuento antes de impuesto
7. Cantidad cero → la línea no suma al total
8. Producto sin precio o null → error controlado, no NaN
9. Redondeo a dos decimales
10. Venta vacía → total 0
11. Cantidad negativa → rechazo por validación

## Criterio de aceptación

- ✅ Los **11 casos en verde**.
- ✅ Cobertura de `sales.js`: **100% líneas / 95.45% statements / 94.44% branches** (> 70% requerido).

```
 Test Files  1 passed (1)
      Tests  11 passed (11)
 sales.js | 95.45% Stmts | 94.44% Branch | 100% Funcs | 100% Lines
```

## Nota (fuera de alcance)

`tests/authStore.test.js` falla con `localStorage.clear is not a function` (limitación de happy-dom). **Ya existe en `develop`**, es ajeno a este PR y no se toca aquí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
