### PR TITLE
Test/auth permisos controller

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.10",
     "cross-env": "^7.0.3",
+    "supertest": "^7.2.2",
     "vitest": "^4.1.10"
   },
   "dependencies": {

--- a/backend/tests/authz.controller.test.js
+++ b/backend/tests/authz.controller.test.js
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Mockeamos el pool para no tocar Postgres: controlamos cada consulta.
+vi.mock('../src/db/pool.js', () => ({
+  default: { query: vi.fn() },
+}))
+
+import request from 'supertest'
+import pool from '../src/db/pool.js'
+import {
+  buildTestApp,
+  signToken,
+  companyMembership,
+  noMembership,
+  dbRows,
+} from './helpers/authTestApp.js'
+
+const app = buildTestApp()
+const validReport = { titulo: 'Reporte de avance', tipo: 'AVANCE', id_proyecto: 10 }
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('Autenticación y permisos a nivel de controller (HU-31)', () => {
+  describe('Autenticación (requireAuth)', () => {
+    it('caso 1 · petición sin token → 401', async () => {
+      const res = await request(app).get('/api/reports').set('X-Company-ID', '1')
+
+      expect(res.status).toBe(401)
+      expect(pool.query).not.toHaveBeenCalled()
+    })
+
+    it('caso 2a · token inválido → 401', async () => {
+      const res = await request(app)
+        .get('/api/reports')
+        .set('Authorization', 'Bearer token-basura')
+        .set('X-Company-ID', '1')
+
+      expect(res.status).toBe(401)
+    })
+
+    it('caso 2b · token expirado → 401', async () => {
+      const res = await request(app)
+        .get('/api/reports')
+        .set('Authorization', `Bearer ${signToken({}, { expiresIn: '-1s' })}`)
+        .set('X-Company-ID', '1')
+
+      expect(res.status).toBe(401)
+    })
+  })
+
+  // Endpoint de management (owner/admin/manager): POST /api/reports
+  describe('Acceso permitido por rol', () => {
+    it('caso 3 · Administrador en endpoint restringido → 201', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValue(dbRows())
+
+      const res = await request(app)
+        .post('/api/reports')
+        .set('Authorization', `Bearer ${signToken()}`)
+        .set('X-Company-ID', '1')
+        .send(validReport)
+
+      expect(res.status).toBe(201)
+    })
+
+    it('caso 4 · Encargado (manager) en endpoint permitido → 201', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('manager'))
+        .mockResolvedValue(dbRows())
+
+      const res = await request(app)
+        .post('/api/reports')
+        .set('Authorization', `Bearer ${signToken()}`)
+        .set('X-Company-ID', '1')
+        .send(validReport)
+
+      expect(res.status).toBe(201)
+    })
+  })
+
+  describe('Acceso denegado por rol', () => {
+    it('caso 5 · Colaborador en endpoint de administrador → 403', async () => {
+      pool.query.mockResolvedValueOnce(companyMembership('collaborator'))
+
+      const res = await request(app)
+        .post('/api/reports')
+        .set('Authorization', `Bearer ${signToken()}`)
+        .set('X-Company-ID', '1')
+        .send(validReport)
+
+      expect(res.status).toBe(403)
+    })
+
+    // DELETE /api/reports/:id es solo owner/admin (NO manager).
+    it('caso 6 · Encargado (manager) en endpoint solo-admin → 403', async () => {
+      pool.query.mockResolvedValueOnce(companyMembership('manager'))
+
+      const res = await request(app)
+        .delete('/api/reports/1')
+        .set('Authorization', `Bearer ${signToken()}`)
+        .set('X-Company-ID', '1')
+
+      expect(res.status).toBe(403)
+    })
+  })
+
+  describe('Aislamiento entre empresas', () => {
+    it('caso 7 · usuario de empresa A pide recurso de empresa B → 403', async () => {
+      pool.query.mockResolvedValueOnce(noMembership())
+
+      const res = await request(app)
+        .get('/api/reports')
+        .set('Authorization', `Bearer ${signToken()}`)
+        .set('X-Company-ID', '999')
+
+      expect(res.status).toBe(403)
+    })
+  })
+
+  describe('Tareas del colaborador', () => {
+    // Brecha: getTasks no filtra por usuario asignado. Este test evidencia el
+    // comportamiento actual (devuelve todas). Escalar como ticket.
+    it('caso 8 · hoy el colaborador recibe TODAS las tareas, no solo las suyas', async () => {
+      const tareas = [
+        { id_tarea: 1, asignado_id: 7 },
+        { id_tarea: 2, asignado_id: 99 },
+      ]
+      pool.query.mockResolvedValueOnce(dbRows(tareas))
+
+      const res = await request(app)
+        .get('/api/projects/5/tasks')
+        .set('Authorization', `Bearer ${signToken({ id_usuario: 7 })}`)
+
+      expect(res.status).toBe(200)
+      expect(res.body.data).toHaveLength(2)
+      expect(res.body.data.some((t) => t.asignado_id === 99)).toBe(true)
+    })
+  })
+
+  describe('Permiso efectivo tras cambio de rol', () => {
+    // Mismo token; solo cambia el rol que reporta la BD → cambia el permiso.
+    it('caso 9 · el mismo usuario pasa de 403 a 200 al cambiar de colaborador a admin', async () => {
+      const token = signToken()
+
+      pool.query
+        .mockResolvedValueOnce(companyMembership('collaborator'))
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValue(dbRows())
+
+      const denegado = await request(app)
+        .delete('/api/reports/1')
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Company-ID', '1')
+
+      const permitido = await request(app)
+        .delete('/api/reports/1')
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Company-ID', '1')
+
+      expect(denegado.status).toBe(403)
+      expect(permitido.status).toBe(200)
+    })
+  })
+})

--- a/backend/tests/helpers/authTestApp.js
+++ b/backend/tests/helpers/authTestApp.js
@@ -1,0 +1,52 @@
+import express from 'express'
+import jwt from 'jsonwebtoken'
+
+import reportsRoutes from '../../src/routes/reportsRoutes.js'
+import projectRoutes from '../../src/routes/projectRoutes.js'
+import taskRoutes from '../../src/routes/taskRoutes.js'
+import companyRoutes from '../../src/routes/companyRoutes.js'
+
+export const JWT_SECRET = 'secreto-de-pruebas-hu31'
+process.env.JWT_SECRET = JWT_SECRET
+
+// Firma un JWT de prueba.
+export function signToken(overrides = {}, options = {}) {
+  return jwt.sign(
+    { id_usuario: 7, email: 'ivana@kontrol.gt', nombre_rol: 'user', ...overrides },
+    JWT_SECRET,
+    options
+  )
+}
+
+// Usuario SÍ pertenece a la empresa.
+export function companyMembership(rol_empresa, { activo = true, nombre = 'Empresa A' } = {}) {
+  return { rows: [{ id_rol_empresa: 1, rol_empresa, activo, nombre }] }
+}
+
+// Usuario NO pertenece a la empresa.
+export function noMembership() {
+  return { rows: [] }
+}
+
+// Filas genéricas para que el controller no responda 404.
+export function dbRows(rows = [{ id_proyecto: 10, id_reporte: 1 }]) {
+  return { rows, rowCount: rows.length }
+}
+
+// App con los routers reales bajo los mismos paths que producción.
+export function buildTestApp() {
+  const app = express()
+  app.use(express.json())
+
+  app.use('/api/reports', reportsRoutes)
+  app.use('/api/projects', projectRoutes)
+  app.use('/api/projects/:projectId/tasks', taskRoutes)
+  app.use('/api/companies', companyRoutes)
+
+  // eslint-disable-next-line no-unused-vars
+  app.use((err, req, res, next) => {
+    res.status(500).json({ success: false, message: err.message })
+  })
+
+  return app
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.10",
         "cross-env": "^7.0.3",
+        "supertest": "^7.2.2",
         "vitest": "^4.1.10"
       },
       "engines": {
@@ -874,6 +875,19 @@
         "win32"
       ]
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@one-ini/wasm": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
@@ -888,6 +902,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1765,6 +1789,13 @@
       "version": "1.1.1",
       "license": "MIT"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1796,6 +1827,13 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2015,6 +2053,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -2023,6 +2074,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/concurrently": {
@@ -2096,6 +2157,13 @@
       "version": "1.0.7",
       "license": "MIT"
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "license": "MIT",
@@ -2165,6 +2233,16 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "license": "MIT",
@@ -2188,6 +2266,17 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dompurify": {
@@ -2420,6 +2509,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -2569,6 +2674,13 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2647,6 +2759,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "license": "MIT",
@@ -2655,6 +2784,24 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -2881,8 +3028,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
-      "version": "2.0.2",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3658,6 +3823,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -4485,6 +4660,90 @@
         "node": ">=8"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -5026,6 +5285,13 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.3",


### PR DESCRIPTION
## Summary
Adds controller-level tests for auth and permissions, exercising the real protected endpoints (supertest + Vitest, Postgres pool mocked). Covers HU-31's 9 cases across the three roles.


## Type of change
- [ ] `feat` – new feature
- [ ] `fix` – bug fix
- [ ] `refactor` – code change that is neither a fix nor a feature
- [ ] `docs` – documentation only
- [x] `test` – adding or updating tests
- [x] `chore` – build, config, dependencies

## Related issue / task
HU-31

## Testing
- [ ] Tested manually (Postman / browser)
- [x] Unit tests pass
- [ ] No regressions on existing endpoints

## Checklist
- [x] Branch follows naming convention (`type/short-description`)
- [x] Commits follow Conventional Commits (`type(scope): message`)
- [x] No secrets or credentials committed
- [x] `password_hash` or sensitive fields are not exposed in responses
- [ ] `.env.example` updated if new env vars were added
