### PR TITLE
test(budget): add automated tests for spend accumulation and overrun alert

### DIFF
--- a/backend/src/controllers/budgetController.js
+++ b/backend/src/controllers/budgetController.js
@@ -1,5 +1,10 @@
 import pool from '../db/pool.js'
 import { notifyCompany } from '../services/notificationService.js'
+import {
+  calculateUsageRatio,
+  computeAlert,
+  sumExpenses,
+} from '../utils/budgetCalculations.js'
 
 const ACTIVITY_SELECT = `
   pa.id_actividad, pa.nombre, pa.monto_planificado, pa.monto_real, pa.id_proyecto
@@ -9,33 +14,8 @@ const PROJECT_SCOPE_JOIN = `
   JOIN public.proyecto p ON p.id_proyecto = pa.id_proyecto
 `
 
-// ── Alert levels ─────────────────────────────────────────────────────────────
-// Granular thresholds let the UI surface a richer signal than just "warning".
-const ALERT_LEVELS = {
-  SALUDABLE:   { threshold: 0,    message: 'Budget on track.' },
-  PRECAUCION:  { threshold: 0.6,  message: '60% of the budget has been used. Monitor spending.' },
-  ADVERTENCIA: { threshold: 0.8,  message: 'More than 80% of the budget has been used.' },
-  CRITICO:     { threshold: 1.0,  message: 'The project budget has been fully consumed.' },
-  EXCEDIDO:    { threshold: 1.0001, message: 'Spending has exceeded the allocated budget.' },
-}
-
-const computeAlert = (usageRatio, totalBudget) => {
-  if (!totalBudget || totalBudget <= 0) {
-    return { alerta: null, alerta_nivel: null }
-  }
-
-  let level = 'SALUDABLE'
-  if (usageRatio > ALERT_LEVELS.EXCEDIDO.threshold) level = 'EXCEDIDO'
-  else if (usageRatio >= ALERT_LEVELS.CRITICO.threshold) level = 'CRITICO'
-  else if (usageRatio >= ALERT_LEVELS.ADVERTENCIA.threshold) level = 'ADVERTENCIA'
-  else if (usageRatio >= ALERT_LEVELS.PRECAUCION.threshold) level = 'PRECAUCION'
-
-  if (level === 'SALUDABLE') {
-    return { alerta: null, alerta_nivel: 'SALUDABLE' }
-  }
-
-  return { alerta: ALERT_LEVELS[level].message, alerta_nivel: level }
-}
+// Alert thresholds and the accumulated-spend math live in
+// utils/budgetCalculations.js so they can be exercised without a database.
 
 // ── Project scope helper ─────────────────────────────────────────────────────
 const ensureProjectInCompany = async (client, projectId, id_empresa) => {
@@ -129,9 +109,7 @@ const buildProjectBudgetSummaryData = async (client, projectId, id_empresa) => {
   const totalPlanned = activities.reduce(
     (sum, activity) => sum + activity.monto_planificado, 0
   )
-  const totalActividades = activities.reduce(
-    (sum, activity) => sum + activity.monto_real, 0
-  )
+  const totalActividades = sumExpenses(activities.map((a) => a.monto_real))
 
   const inv = {
     ENTRADA: { total: 0, movimientos: 0 },
@@ -150,7 +128,7 @@ const buildProjectBudgetSummaryData = async (client, projectId, id_empresa) => {
   const ingresosTotales = inv.SALIDA.total
   const resultadoNeto = ingresosTotales - egresosTotales
   const disponible = totalBudget - egresosTotales
-  const usageRatio = totalBudget > 0 ? egresosTotales / totalBudget : 0
+  const usageRatio = calculateUsageRatio(egresosTotales, totalBudget)
 
   const { alerta, alerta_nivel } = computeAlert(usageRatio, totalBudget)
 

--- a/backend/src/utils/budgetCalculations.js
+++ b/backend/src/utils/budgetCalculations.js
@@ -1,0 +1,107 @@
+// Pure budget math: accumulated spending, budget usage and overrun alerts.
+// Kept free of DB access so the money-critical rules can be tested directly
+// and reused by any controller that needs the same semantics.
+
+// ── Alert levels ─────────────────────────────────────────────────────────────
+// Granular thresholds let the UI surface a richer signal than just "warning".
+export const ALERT_LEVELS = {
+  SALUDABLE:   { threshold: 0,      message: 'Budget on track.' },
+  PRECAUCION:  { threshold: 0.6,    message: '60% of the budget has been used. Monitor spending.' },
+  ADVERTENCIA: { threshold: 0.8,    message: 'More than 80% of the budget has been used.' },
+  CRITICO:     { threshold: 1.0,    message: 'The project budget has been fully consumed.' },
+  EXCEDIDO:    { threshold: 1.0001, message: 'Spending has exceeded the allocated budget.' },
+}
+
+// Money is rounded to cents on every aggregation so float noise never leaks
+// into a total the user sees or compares against the budget.
+const CENTS = 2
+
+const roundMoney = (value) => Number(value.toFixed(CENTS))
+
+// Accepts a raw number, a numeric string (pg returns numeric as string) or an
+// expense-like object. Anything else is a programming/data error.
+const readAmount = (expense) => {
+  const raw = (expense !== null && typeof expense === 'object')
+    ? (expense.monto ?? expense.monto_real ?? expense.expenseAmount)
+    : expense
+
+  const amount = typeof raw === 'string' ? Number(raw) : raw
+
+  if (typeof amount !== 'number' || !Number.isFinite(amount)) {
+    throw new TypeError('El monto del gasto debe ser un número válido.')
+  }
+  if (amount < 0) {
+    throw new RangeError('El monto del gasto no puede ser negativo.')
+  }
+
+  return amount
+}
+
+/**
+ * Accumulated spending for a project: the sum of all its expenses.
+ * A project without expenses accumulates 0.
+ */
+export const sumExpenses = (expenses = []) => {
+  if (!Array.isArray(expenses)) {
+    throw new TypeError('La lista de gastos debe ser un arreglo.')
+  }
+
+  return roundMoney(expenses.reduce((total, expense) => total + readAmount(expense), 0))
+}
+
+/**
+ * Share of the budget already consumed, as a ratio (1 === budget exhausted).
+ * A budget of 0 (or missing) yields 0 instead of dividing by zero.
+ */
+export const calculateUsageRatio = (totalSpent, totalBudget) => {
+  if (!totalBudget || totalBudget <= 0) return 0
+  return totalSpent / totalBudget
+}
+
+/** Same ratio expressed as a percentage, rounded to two decimals. */
+export const calculateUsagePercentage = (totalSpent, totalBudget) =>
+  roundMoney(calculateUsageRatio(totalSpent, totalBudget) * 100)
+
+/**
+ * Alert level for a usage ratio. Without an allocated budget there is nothing
+ * to compare against, so no alert is emitted.
+ */
+export const computeAlert = (usageRatio, totalBudget) => {
+  if (!totalBudget || totalBudget <= 0) {
+    return { alerta: null, alerta_nivel: null }
+  }
+
+  let level = 'SALUDABLE'
+  if (usageRatio > ALERT_LEVELS.EXCEDIDO.threshold) level = 'EXCEDIDO'
+  else if (usageRatio >= ALERT_LEVELS.CRITICO.threshold) level = 'CRITICO'
+  else if (usageRatio >= ALERT_LEVELS.ADVERTENCIA.threshold) level = 'ADVERTENCIA'
+  else if (usageRatio >= ALERT_LEVELS.PRECAUCION.threshold) level = 'PRECAUCION'
+
+  if (level === 'SALUDABLE') {
+    return { alerta: null, alerta_nivel: 'SALUDABLE' }
+  }
+
+  return { alerta: ALERT_LEVELS[level].message, alerta_nivel: level }
+}
+
+/**
+ * Full budget status for a project from its allocated budget and its expenses.
+ * Single entry point for the "accumulated spend vs. budget" rule.
+ */
+export const buildBudgetStatus = ({ presupuesto_total = 0, gastos = [] } = {}) => {
+  const totalBudget = Number(presupuesto_total) || 0
+  const totalSpent = sumExpenses(gastos)
+  const usageRatio = calculateUsageRatio(totalSpent, totalBudget)
+  const { alerta, alerta_nivel } = computeAlert(usageRatio, totalBudget)
+
+  return {
+    presupuesto_total: roundMoney(totalBudget),
+    total_gastado: totalSpent,
+    disponible: roundMoney(totalBudget - totalSpent),
+    porcentaje_uso: Number(usageRatio.toFixed(4)),
+    porcentaje_completado: Math.min(100, Math.round(usageRatio * 100)),
+    sobrecosto: totalBudget > 0 && totalSpent > totalBudget,
+    alerta,
+    alerta_nivel,
+  }
+}

--- a/backend/tests/budgetCalculations.test.js
+++ b/backend/tests/budgetCalculations.test.js
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ALERT_LEVELS,
+  buildBudgetStatus,
+  calculateUsagePercentage,
+  calculateUsageRatio,
+  computeAlert,
+  sumExpenses,
+} from '../src/utils/budgetCalculations.js'
+import { expenseSchema } from '../src/schemas/budgetSchema.js'
+
+// HU-30 · Cálculo de gasto acumulado contra presupuesto total y alerta de sobrecosto.
+
+describe('Caso 1 · Gasto acumulado igual a la suma de gastos del proyecto', () => {
+  it('acumula la lista de montos del proyecto', () => {
+    expect(sumExpenses([1500, 2300.5, 700.25])).toBe(4500.75)
+  })
+
+  it('acepta gastos como objetos y como numeric de Postgres (string)', () => {
+    expect(sumExpenses([{ monto: 1200 }, { monto_real: '800.40' }, '199.60'])).toBe(2200)
+    // el payload del endpoint de registro de gastos usa expenseAmount
+    expect(sumExpenses([{ expenseAmount: 350 }, { expenseAmount: 150 }])).toBe(500)
+  })
+
+  it('redondea a centavos para que el acumulado no arrastre ruido de punto flotante', () => {
+    // 0.1 + 0.2 === 0.30000000000000004 en aritmética IEEE-754
+    expect(sumExpenses([0.1, 0.2])).toBe(0.3)
+  })
+
+  it('el acumulado coincide con el total reportado en el estado del presupuesto', () => {
+    const gastos = [1000, 250.75, 99.25]
+    const status = buildBudgetStatus({ presupuesto_total: 5000, gastos })
+
+    expect(status.total_gastado).toBe(sumExpenses(gastos))
+    expect(status.total_gastado).toBe(1350)
+    expect(status.disponible).toBe(3650)
+  })
+})
+
+describe('Caso 2 · Porcentaje consumido del presupuesto', () => {
+  it('calcula la razón de uso sobre el presupuesto total', () => {
+    expect(calculateUsageRatio(2500, 10000)).toBe(0.25)
+  })
+
+  it('expresa el consumo como porcentaje con dos decimales', () => {
+    expect(calculateUsagePercentage(2500, 10000)).toBe(25)
+    expect(calculateUsagePercentage(3333, 10000)).toBe(33.33)
+  })
+
+  it('publica el porcentaje en el estado del presupuesto', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 8000, gastos: [2000, 2000] })
+
+    expect(status.porcentaje_uso).toBe(0.5)
+    expect(status.porcentaje_completado).toBe(50)
+  })
+
+  it('limita el porcentaje mostrado a 100 aunque el gasto lo supere', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 1000, gastos: [3000] })
+
+    expect(status.porcentaje_uso).toBe(3)
+    expect(status.porcentaje_completado).toBe(100)
+  })
+})
+
+describe('Caso 3 · Gasto menor al presupuesto → sin alerta', () => {
+  it('no emite alerta cuando el consumo está por debajo del primer umbral', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 10000, gastos: [1000, 2000] })
+
+    expect(status.alerta).toBeNull()
+    expect(status.alerta_nivel).toBe('SALUDABLE')
+    expect(status.sobrecosto).toBe(false)
+    expect(status.disponible).toBe(7000)
+  })
+
+  it('marca PRECAUCION sin ser sobrecosto al pasar el 60%', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 10000, gastos: [6500] })
+
+    expect(status.alerta_nivel).toBe('PRECAUCION')
+    expect(status.sobrecosto).toBe(false)
+  })
+})
+
+describe('Caso 4 · Gasto igual al presupuesto → alerta en el umbral exacto', () => {
+  it('emite CRITICO cuando el gasto iguala exactamente el presupuesto', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 5000, gastos: [2500, 2500] })
+
+    expect(status.porcentaje_uso).toBe(1)
+    expect(status.alerta_nivel).toBe('CRITICO')
+    expect(status.alerta).toBe(ALERT_LEVELS.CRITICO.message)
+    expect(status.disponible).toBe(0)
+  })
+
+  it('en el umbral exacto todavía no se considera sobrecosto', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 5000, gastos: [5000] })
+
+    expect(status.sobrecosto).toBe(false)
+    expect(status.alerta_nivel).not.toBe('EXCEDIDO')
+  })
+})
+
+describe('Caso 5 · Gasto mayor al presupuesto → alerta de sobrecosto', () => {
+  it('emite EXCEDIDO y disponible negativo cuando se supera el presupuesto', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 10000, gastos: [8000, 4000] })
+
+    expect(status.alerta_nivel).toBe('EXCEDIDO')
+    expect(status.alerta).toBe(ALERT_LEVELS.EXCEDIDO.message)
+    expect(status.sobrecosto).toBe(true)
+    expect(status.disponible).toBe(-2000)
+  })
+
+  it('escala de CRITICO a EXCEDIDO al cruzar el presupuesto', () => {
+    expect(computeAlert(1.0, 10000).alerta_nivel).toBe('CRITICO')
+    expect(computeAlert(1.01, 10000).alerta_nivel).toBe('EXCEDIDO')
+  })
+})
+
+describe('Caso 6 · Presupuesto cero → sin división por cero', () => {
+  it('devuelve razón 0 en lugar de Infinity o NaN', () => {
+    expect(calculateUsageRatio(5000, 0)).toBe(0)
+    expect(calculateUsagePercentage(5000, 0)).toBe(0)
+    expect(Number.isFinite(calculateUsageRatio(5000, 0))).toBe(true)
+  })
+
+  it('no emite alerta si no hay presupuesto asignado contra el cual comparar', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 0, gastos: [1200] })
+
+    expect(status.porcentaje_uso).toBe(0)
+    expect(status.alerta).toBeNull()
+    expect(status.alerta_nivel).toBeNull()
+    expect(status.sobrecosto).toBe(false)
+    // el gasto se sigue acumulando aunque no haya presupuesto
+    expect(status.total_gastado).toBe(1200)
+  })
+
+  it('trata un presupuesto ausente o nulo como cero', () => {
+    expect(calculateUsageRatio(100, null)).toBe(0)
+    expect(calculateUsageRatio(100, undefined)).toBe(0)
+    expect(computeAlert(2, null)).toEqual({ alerta: null, alerta_nivel: null })
+    expect(buildBudgetStatus().presupuesto_total).toBe(0)
+  })
+})
+
+describe('Caso 7 · Gasto negativo → rechazo por validación', () => {
+  it('rechaza un monto negativo dentro del acumulado', () => {
+    expect(() => sumExpenses([1000, -500])).toThrow(RangeError)
+    expect(() => sumExpenses([-1])).toThrow(/no puede ser negativo/i)
+  })
+
+  it('rechaza montos no numéricos', () => {
+    expect(() => sumExpenses(['abc'])).toThrow(TypeError)
+    expect(() => sumExpenses([null])).toThrow(TypeError)
+    expect(() => sumExpenses('no-es-arreglo')).toThrow(/arreglo/i)
+  })
+
+  it('el esquema del endpoint rechaza un gasto negativo o cero antes de registrarlo', () => {
+    const negativo = expenseSchema.safeParse({
+      projectId: 1,
+      activityName: 'Materiales',
+      expenseAmount: -250,
+    })
+    const cero = expenseSchema.safeParse({
+      projectId: 1,
+      activityName: 'Materiales',
+      expenseAmount: 0,
+    })
+
+    expect(negativo.success).toBe(false)
+    expect(cero.success).toBe(false)
+  })
+
+  it('el esquema acepta un gasto positivo válido', () => {
+    const result = expenseSchema.safeParse({
+      projectId: 1,
+      activityName: 'Materiales',
+      expenseAmount: 250.5,
+      motivo: 'Compra de cemento',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data.expenseAmount).toBe(250.5)
+  })
+})
+
+describe('Caso 8 · Proyecto sin gastos → acumulado 0', () => {
+  it('acumula 0 con lista vacía o sin argumento', () => {
+    expect(sumExpenses([])).toBe(0)
+    expect(sumExpenses()).toBe(0)
+  })
+
+  it('reporta presupuesto íntegro disponible y sin alerta', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 15000, gastos: [] })
+
+    expect(status.total_gastado).toBe(0)
+    expect(status.disponible).toBe(15000)
+    expect(status.porcentaje_uso).toBe(0)
+    expect(status.porcentaje_completado).toBe(0)
+    expect(status.alerta).toBeNull()
+    expect(status.alerta_nivel).toBe('SALUDABLE')
+  })
+})
+
+describe('Caso 9 · Umbral de advertencia al 80% del presupuesto', () => {
+  it('no advierte justo por debajo del 80%', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 10000, gastos: [7999.99] })
+
+    expect(status.alerta_nivel).toBe('PRECAUCION')
+  })
+
+  it('advierte exactamente en el 80% del presupuesto', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 10000, gastos: [8000] })
+
+    expect(status.porcentaje_uso).toBe(0.8)
+    expect(status.alerta_nivel).toBe('ADVERTENCIA')
+    expect(status.alerta).toBe(ALERT_LEVELS.ADVERTENCIA.message)
+    expect(status.sobrecosto).toBe(false)
+  })
+
+  it('mantiene ADVERTENCIA entre el 80% y el 100%', () => {
+    expect(computeAlert(0.8, 1000).alerta_nivel).toBe('ADVERTENCIA')
+    expect(computeAlert(0.95, 1000).alerta_nivel).toBe('ADVERTENCIA')
+    expect(computeAlert(0.9999, 1000).alerta_nivel).toBe('ADVERTENCIA')
+  })
+
+  it('el umbral de advertencia declarado es 0.8', () => {
+    expect(ALERT_LEVELS.ADVERTENCIA.threshold).toBe(0.8)
+  })
+})


### PR DESCRIPTION
## Summary
Extrae el cálculo de gasto acumulado, porcentaje de uso y alerta de sobrecosto de `budgetController` a `src/utils/budgetCalculations.js`, y automatiza los 9 casos de prueba de HU-30 con Vitest. Cobertura del módulo: 100%.

## Type of change
- [ ] `feat` – new feature
- [ ] `fix` – bug fix
- [x] `refactor` – code change that is neither a fix nor a feature
- [ ] `docs` – documentation only
- [x] `test` – adding or updating tests
- [ ] `chore` – build, config, dependencies

## Related issue / task
Task HU-30

## Testing
`npm test` en `backend/` → 5 archivos, 49 tests en verde (4 previos + 28 nuevos).
`npx vitest run --coverage --coverage.include="src/utils/budgetCalculations.js"` → 100% statements / branches / functions / lines.

Casos cubiertos: gasto acumulado, porcentaje consumido, sin alerta, alerta en umbral exacto, sobrecosto, presupuesto cero sin división por cero, gasto negativo rechazado, proyecto sin gastos, umbral de advertencia al 80%.

- [ ] Tested manually (Postman / browser)
- [x] Unit tests pass
- [ ] No regressions on existing endpoints

## Checklist
- [x] Branch follows naming convention (`type/short-description`)
- [x] Commits follow Conventional Commits (`type(scope): message`)
- [x] No secrets or credentials committed
- [x] `password_hash` or sensitive fields are not exposed in responses
- [x] `.env.example` updated if new env vars were added (N/A)