### PR TITLE
release: automated test suite, testable POS/budget/auth modules and CI gate

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.10",
     "cross-env": "^7.0.3",
+    "supertest": "^7.2.2",
     "vitest": "^4.1.10"
   },
   "dependencies": {

--- a/backend/src/controllers/budgetController.js
+++ b/backend/src/controllers/budgetController.js
@@ -1,5 +1,10 @@
 import pool from '../db/pool.js'
 import { notifyCompany } from '../services/notificationService.js'
+import {
+  calculateUsageRatio,
+  computeAlert,
+  sumExpenses,
+} from '../utils/budgetCalculations.js'
 
 const ACTIVITY_SELECT = `
   pa.id_actividad, pa.nombre, pa.monto_planificado, pa.monto_real, pa.id_proyecto
@@ -9,33 +14,8 @@ const PROJECT_SCOPE_JOIN = `
   JOIN public.proyecto p ON p.id_proyecto = pa.id_proyecto
 `
 
-// ── Alert levels ─────────────────────────────────────────────────────────────
-// Granular thresholds let the UI surface a richer signal than just "warning".
-const ALERT_LEVELS = {
-  SALUDABLE:   { threshold: 0,    message: 'Budget on track.' },
-  PRECAUCION:  { threshold: 0.6,  message: '60% of the budget has been used. Monitor spending.' },
-  ADVERTENCIA: { threshold: 0.8,  message: 'More than 80% of the budget has been used.' },
-  CRITICO:     { threshold: 1.0,  message: 'The project budget has been fully consumed.' },
-  EXCEDIDO:    { threshold: 1.0001, message: 'Spending has exceeded the allocated budget.' },
-}
-
-const computeAlert = (usageRatio, totalBudget) => {
-  if (!totalBudget || totalBudget <= 0) {
-    return { alerta: null, alerta_nivel: null }
-  }
-
-  let level = 'SALUDABLE'
-  if (usageRatio > ALERT_LEVELS.EXCEDIDO.threshold) level = 'EXCEDIDO'
-  else if (usageRatio >= ALERT_LEVELS.CRITICO.threshold) level = 'CRITICO'
-  else if (usageRatio >= ALERT_LEVELS.ADVERTENCIA.threshold) level = 'ADVERTENCIA'
-  else if (usageRatio >= ALERT_LEVELS.PRECAUCION.threshold) level = 'PRECAUCION'
-
-  if (level === 'SALUDABLE') {
-    return { alerta: null, alerta_nivel: 'SALUDABLE' }
-  }
-
-  return { alerta: ALERT_LEVELS[level].message, alerta_nivel: level }
-}
+// Alert thresholds and the accumulated-spend math live in
+// utils/budgetCalculations.js so they can be exercised without a database.
 
 // ── Project scope helper ─────────────────────────────────────────────────────
 const ensureProjectInCompany = async (client, projectId, id_empresa) => {
@@ -129,9 +109,7 @@ const buildProjectBudgetSummaryData = async (client, projectId, id_empresa) => {
   const totalPlanned = activities.reduce(
     (sum, activity) => sum + activity.monto_planificado, 0
   )
-  const totalActividades = activities.reduce(
-    (sum, activity) => sum + activity.monto_real, 0
-  )
+  const totalActividades = sumExpenses(activities.map((a) => a.monto_real))
 
   const inv = {
     ENTRADA: { total: 0, movimientos: 0 },
@@ -150,7 +128,7 @@ const buildProjectBudgetSummaryData = async (client, projectId, id_empresa) => {
   const ingresosTotales = inv.SALIDA.total
   const resultadoNeto = ingresosTotales - egresosTotales
   const disponible = totalBudget - egresosTotales
-  const usageRatio = totalBudget > 0 ? egresosTotales / totalBudget : 0
+  const usageRatio = calculateUsageRatio(egresosTotales, totalBudget)
 
   const { alerta, alerta_nivel } = computeAlert(usageRatio, totalBudget)
 

--- a/backend/src/utils/budgetCalculations.js
+++ b/backend/src/utils/budgetCalculations.js
@@ -1,0 +1,107 @@
+// Pure budget math: accumulated spending, budget usage and overrun alerts.
+// Kept free of DB access so the money-critical rules can be tested directly
+// and reused by any controller that needs the same semantics.
+
+// ── Alert levels ─────────────────────────────────────────────────────────────
+// Granular thresholds let the UI surface a richer signal than just "warning".
+export const ALERT_LEVELS = {
+  SALUDABLE:   { threshold: 0,      message: 'Budget on track.' },
+  PRECAUCION:  { threshold: 0.6,    message: '60% of the budget has been used. Monitor spending.' },
+  ADVERTENCIA: { threshold: 0.8,    message: 'More than 80% of the budget has been used.' },
+  CRITICO:     { threshold: 1.0,    message: 'The project budget has been fully consumed.' },
+  EXCEDIDO:    { threshold: 1.0001, message: 'Spending has exceeded the allocated budget.' },
+}
+
+// Money is rounded to cents on every aggregation so float noise never leaks
+// into a total the user sees or compares against the budget.
+const CENTS = 2
+
+const roundMoney = (value) => Number(value.toFixed(CENTS))
+
+// Accepts a raw number, a numeric string (pg returns numeric as string) or an
+// expense-like object. Anything else is a programming/data error.
+const readAmount = (expense) => {
+  const raw = (expense !== null && typeof expense === 'object')
+    ? (expense.monto ?? expense.monto_real ?? expense.expenseAmount)
+    : expense
+
+  const amount = typeof raw === 'string' ? Number(raw) : raw
+
+  if (typeof amount !== 'number' || !Number.isFinite(amount)) {
+    throw new TypeError('El monto del gasto debe ser un número válido.')
+  }
+  if (amount < 0) {
+    throw new RangeError('El monto del gasto no puede ser negativo.')
+  }
+
+  return amount
+}
+
+/**
+ * Accumulated spending for a project: the sum of all its expenses.
+ * A project without expenses accumulates 0.
+ */
+export const sumExpenses = (expenses = []) => {
+  if (!Array.isArray(expenses)) {
+    throw new TypeError('La lista de gastos debe ser un arreglo.')
+  }
+
+  return roundMoney(expenses.reduce((total, expense) => total + readAmount(expense), 0))
+}
+
+/**
+ * Share of the budget already consumed, as a ratio (1 === budget exhausted).
+ * A budget of 0 (or missing) yields 0 instead of dividing by zero.
+ */
+export const calculateUsageRatio = (totalSpent, totalBudget) => {
+  if (!totalBudget || totalBudget <= 0) return 0
+  return totalSpent / totalBudget
+}
+
+/** Same ratio expressed as a percentage, rounded to two decimals. */
+export const calculateUsagePercentage = (totalSpent, totalBudget) =>
+  roundMoney(calculateUsageRatio(totalSpent, totalBudget) * 100)
+
+/**
+ * Alert level for a usage ratio. Without an allocated budget there is nothing
+ * to compare against, so no alert is emitted.
+ */
+export const computeAlert = (usageRatio, totalBudget) => {
+  if (!totalBudget || totalBudget <= 0) {
+    return { alerta: null, alerta_nivel: null }
+  }
+
+  let level = 'SALUDABLE'
+  if (usageRatio > ALERT_LEVELS.EXCEDIDO.threshold) level = 'EXCEDIDO'
+  else if (usageRatio >= ALERT_LEVELS.CRITICO.threshold) level = 'CRITICO'
+  else if (usageRatio >= ALERT_LEVELS.ADVERTENCIA.threshold) level = 'ADVERTENCIA'
+  else if (usageRatio >= ALERT_LEVELS.PRECAUCION.threshold) level = 'PRECAUCION'
+
+  if (level === 'SALUDABLE') {
+    return { alerta: null, alerta_nivel: 'SALUDABLE' }
+  }
+
+  return { alerta: ALERT_LEVELS[level].message, alerta_nivel: level }
+}
+
+/**
+ * Full budget status for a project from its allocated budget and its expenses.
+ * Single entry point for the "accumulated spend vs. budget" rule.
+ */
+export const buildBudgetStatus = ({ presupuesto_total = 0, gastos = [] } = {}) => {
+  const totalBudget = Number(presupuesto_total) || 0
+  const totalSpent = sumExpenses(gastos)
+  const usageRatio = calculateUsageRatio(totalSpent, totalBudget)
+  const { alerta, alerta_nivel } = computeAlert(usageRatio, totalBudget)
+
+  return {
+    presupuesto_total: roundMoney(totalBudget),
+    total_gastado: totalSpent,
+    disponible: roundMoney(totalBudget - totalSpent),
+    porcentaje_uso: Number(usageRatio.toFixed(4)),
+    porcentaje_completado: Math.min(100, Math.round(usageRatio * 100)),
+    sobrecosto: totalBudget > 0 && totalSpent > totalBudget,
+    alerta,
+    alerta_nivel,
+  }
+}

--- a/backend/tests/authz.controller.test.js
+++ b/backend/tests/authz.controller.test.js
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Mockeamos el pool para no tocar Postgres: controlamos cada consulta.
+vi.mock('../src/db/pool.js', () => ({
+  default: { query: vi.fn() },
+}))
+
+import request from 'supertest'
+import pool from '../src/db/pool.js'
+import {
+  buildTestApp,
+  signToken,
+  companyMembership,
+  noMembership,
+  dbRows,
+} from './helpers/authTestApp.js'
+
+const app = buildTestApp()
+const validReport = { titulo: 'Reporte de avance', tipo: 'AVANCE', id_proyecto: 10 }
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('Autenticación y permisos a nivel de controller (HU-31)', () => {
+  describe('Autenticación (requireAuth)', () => {
+    it('caso 1 · petición sin token → 401', async () => {
+      const res = await request(app).get('/api/reports').set('X-Company-ID', '1')
+
+      expect(res.status).toBe(401)
+      expect(pool.query).not.toHaveBeenCalled()
+    })
+
+    it('caso 2a · token inválido → 401', async () => {
+      const res = await request(app)
+        .get('/api/reports')
+        .set('Authorization', 'Bearer token-basura')
+        .set('X-Company-ID', '1')
+
+      expect(res.status).toBe(401)
+    })
+
+    it('caso 2b · token expirado → 401', async () => {
+      const res = await request(app)
+        .get('/api/reports')
+        .set('Authorization', `Bearer ${signToken({}, { expiresIn: '-1s' })}`)
+        .set('X-Company-ID', '1')
+
+      expect(res.status).toBe(401)
+    })
+  })
+
+  // Endpoint de management (owner/admin/manager): POST /api/reports
+  describe('Acceso permitido por rol', () => {
+    it('caso 3 · Administrador en endpoint restringido → 201', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValue(dbRows())
+
+      const res = await request(app)
+        .post('/api/reports')
+        .set('Authorization', `Bearer ${signToken()}`)
+        .set('X-Company-ID', '1')
+        .send(validReport)
+
+      expect(res.status).toBe(201)
+    })
+
+    it('caso 4 · Encargado (manager) en endpoint permitido → 201', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('manager'))
+        .mockResolvedValue(dbRows())
+
+      const res = await request(app)
+        .post('/api/reports')
+        .set('Authorization', `Bearer ${signToken()}`)
+        .set('X-Company-ID', '1')
+        .send(validReport)
+
+      expect(res.status).toBe(201)
+    })
+  })
+
+  describe('Acceso denegado por rol', () => {
+    it('caso 5 · Colaborador en endpoint de administrador → 403', async () => {
+      pool.query.mockResolvedValueOnce(companyMembership('collaborator'))
+
+      const res = await request(app)
+        .post('/api/reports')
+        .set('Authorization', `Bearer ${signToken()}`)
+        .set('X-Company-ID', '1')
+        .send(validReport)
+
+      expect(res.status).toBe(403)
+    })
+
+    // DELETE /api/reports/:id es solo owner/admin (NO manager).
+    it('caso 6 · Encargado (manager) en endpoint solo-admin → 403', async () => {
+      pool.query.mockResolvedValueOnce(companyMembership('manager'))
+
+      const res = await request(app)
+        .delete('/api/reports/1')
+        .set('Authorization', `Bearer ${signToken()}`)
+        .set('X-Company-ID', '1')
+
+      expect(res.status).toBe(403)
+    })
+  })
+
+  describe('Aislamiento entre empresas', () => {
+    it('caso 7 · usuario de empresa A pide recurso de empresa B → 403', async () => {
+      pool.query.mockResolvedValueOnce(noMembership())
+
+      const res = await request(app)
+        .get('/api/reports')
+        .set('Authorization', `Bearer ${signToken()}`)
+        .set('X-Company-ID', '999')
+
+      expect(res.status).toBe(403)
+    })
+  })
+
+  describe('Tareas del colaborador', () => {
+    // Brecha: getTasks no filtra por usuario asignado. Este test evidencia el
+    // comportamiento actual (devuelve todas). Escalar como ticket.
+    it('caso 8 · hoy el colaborador recibe TODAS las tareas, no solo las suyas', async () => {
+      const tareas = [
+        { id_tarea: 1, asignado_id: 7 },
+        { id_tarea: 2, asignado_id: 99 },
+      ]
+      pool.query.mockResolvedValueOnce(dbRows(tareas))
+
+      const res = await request(app)
+        .get('/api/projects/5/tasks')
+        .set('Authorization', `Bearer ${signToken({ id_usuario: 7 })}`)
+
+      expect(res.status).toBe(200)
+      expect(res.body.data).toHaveLength(2)
+      expect(res.body.data.some((t) => t.asignado_id === 99)).toBe(true)
+    })
+  })
+
+  describe('Permiso efectivo tras cambio de rol', () => {
+    // Mismo token; solo cambia el rol que reporta la BD → cambia el permiso.
+    it('caso 9 · el mismo usuario pasa de 403 a 200 al cambiar de colaborador a admin', async () => {
+      const token = signToken()
+
+      pool.query
+        .mockResolvedValueOnce(companyMembership('collaborator'))
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValue(dbRows())
+
+      const denegado = await request(app)
+        .delete('/api/reports/1')
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Company-ID', '1')
+
+      const permitido = await request(app)
+        .delete('/api/reports/1')
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Company-ID', '1')
+
+      expect(denegado.status).toBe(403)
+      expect(permitido.status).toBe(200)
+    })
+  })
+})

--- a/backend/tests/budgetCalculations.test.js
+++ b/backend/tests/budgetCalculations.test.js
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ALERT_LEVELS,
+  buildBudgetStatus,
+  calculateUsagePercentage,
+  calculateUsageRatio,
+  computeAlert,
+  sumExpenses,
+} from '../src/utils/budgetCalculations.js'
+import { expenseSchema } from '../src/schemas/budgetSchema.js'
+
+// HU-30 · Cálculo de gasto acumulado contra presupuesto total y alerta de sobrecosto.
+
+describe('Caso 1 · Gasto acumulado igual a la suma de gastos del proyecto', () => {
+  it('acumula la lista de montos del proyecto', () => {
+    expect(sumExpenses([1500, 2300.5, 700.25])).toBe(4500.75)
+  })
+
+  it('acepta gastos como objetos y como numeric de Postgres (string)', () => {
+    expect(sumExpenses([{ monto: 1200 }, { monto_real: '800.40' }, '199.60'])).toBe(2200)
+    // el payload del endpoint de registro de gastos usa expenseAmount
+    expect(sumExpenses([{ expenseAmount: 350 }, { expenseAmount: 150 }])).toBe(500)
+  })
+
+  it('redondea a centavos para que el acumulado no arrastre ruido de punto flotante', () => {
+    // 0.1 + 0.2 === 0.30000000000000004 en aritmética IEEE-754
+    expect(sumExpenses([0.1, 0.2])).toBe(0.3)
+  })
+
+  it('el acumulado coincide con el total reportado en el estado del presupuesto', () => {
+    const gastos = [1000, 250.75, 99.25]
+    const status = buildBudgetStatus({ presupuesto_total: 5000, gastos })
+
+    expect(status.total_gastado).toBe(sumExpenses(gastos))
+    expect(status.total_gastado).toBe(1350)
+    expect(status.disponible).toBe(3650)
+  })
+})
+
+describe('Caso 2 · Porcentaje consumido del presupuesto', () => {
+  it('calcula la razón de uso sobre el presupuesto total', () => {
+    expect(calculateUsageRatio(2500, 10000)).toBe(0.25)
+  })
+
+  it('expresa el consumo como porcentaje con dos decimales', () => {
+    expect(calculateUsagePercentage(2500, 10000)).toBe(25)
+    expect(calculateUsagePercentage(3333, 10000)).toBe(33.33)
+  })
+
+  it('publica el porcentaje en el estado del presupuesto', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 8000, gastos: [2000, 2000] })
+
+    expect(status.porcentaje_uso).toBe(0.5)
+    expect(status.porcentaje_completado).toBe(50)
+  })
+
+  it('limita el porcentaje mostrado a 100 aunque el gasto lo supere', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 1000, gastos: [3000] })
+
+    expect(status.porcentaje_uso).toBe(3)
+    expect(status.porcentaje_completado).toBe(100)
+  })
+})
+
+describe('Caso 3 · Gasto menor al presupuesto → sin alerta', () => {
+  it('no emite alerta cuando el consumo está por debajo del primer umbral', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 10000, gastos: [1000, 2000] })
+
+    expect(status.alerta).toBeNull()
+    expect(status.alerta_nivel).toBe('SALUDABLE')
+    expect(status.sobrecosto).toBe(false)
+    expect(status.disponible).toBe(7000)
+  })
+
+  it('marca PRECAUCION sin ser sobrecosto al pasar el 60%', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 10000, gastos: [6500] })
+
+    expect(status.alerta_nivel).toBe('PRECAUCION')
+    expect(status.sobrecosto).toBe(false)
+  })
+})
+
+describe('Caso 4 · Gasto igual al presupuesto → alerta en el umbral exacto', () => {
+  it('emite CRITICO cuando el gasto iguala exactamente el presupuesto', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 5000, gastos: [2500, 2500] })
+
+    expect(status.porcentaje_uso).toBe(1)
+    expect(status.alerta_nivel).toBe('CRITICO')
+    expect(status.alerta).toBe(ALERT_LEVELS.CRITICO.message)
+    expect(status.disponible).toBe(0)
+  })
+
+  it('en el umbral exacto todavía no se considera sobrecosto', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 5000, gastos: [5000] })
+
+    expect(status.sobrecosto).toBe(false)
+    expect(status.alerta_nivel).not.toBe('EXCEDIDO')
+  })
+})
+
+describe('Caso 5 · Gasto mayor al presupuesto → alerta de sobrecosto', () => {
+  it('emite EXCEDIDO y disponible negativo cuando se supera el presupuesto', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 10000, gastos: [8000, 4000] })
+
+    expect(status.alerta_nivel).toBe('EXCEDIDO')
+    expect(status.alerta).toBe(ALERT_LEVELS.EXCEDIDO.message)
+    expect(status.sobrecosto).toBe(true)
+    expect(status.disponible).toBe(-2000)
+  })
+
+  it('escala de CRITICO a EXCEDIDO al cruzar el presupuesto', () => {
+    expect(computeAlert(1.0, 10000).alerta_nivel).toBe('CRITICO')
+    expect(computeAlert(1.01, 10000).alerta_nivel).toBe('EXCEDIDO')
+  })
+})
+
+describe('Caso 6 · Presupuesto cero → sin división por cero', () => {
+  it('devuelve razón 0 en lugar de Infinity o NaN', () => {
+    expect(calculateUsageRatio(5000, 0)).toBe(0)
+    expect(calculateUsagePercentage(5000, 0)).toBe(0)
+    expect(Number.isFinite(calculateUsageRatio(5000, 0))).toBe(true)
+  })
+
+  it('no emite alerta si no hay presupuesto asignado contra el cual comparar', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 0, gastos: [1200] })
+
+    expect(status.porcentaje_uso).toBe(0)
+    expect(status.alerta).toBeNull()
+    expect(status.alerta_nivel).toBeNull()
+    expect(status.sobrecosto).toBe(false)
+    // el gasto se sigue acumulando aunque no haya presupuesto
+    expect(status.total_gastado).toBe(1200)
+  })
+
+  it('trata un presupuesto ausente o nulo como cero', () => {
+    expect(calculateUsageRatio(100, null)).toBe(0)
+    expect(calculateUsageRatio(100, undefined)).toBe(0)
+    expect(computeAlert(2, null)).toEqual({ alerta: null, alerta_nivel: null })
+    expect(buildBudgetStatus().presupuesto_total).toBe(0)
+  })
+})
+
+describe('Caso 7 · Gasto negativo → rechazo por validación', () => {
+  it('rechaza un monto negativo dentro del acumulado', () => {
+    expect(() => sumExpenses([1000, -500])).toThrow(RangeError)
+    expect(() => sumExpenses([-1])).toThrow(/no puede ser negativo/i)
+  })
+
+  it('rechaza montos no numéricos', () => {
+    expect(() => sumExpenses(['abc'])).toThrow(TypeError)
+    expect(() => sumExpenses([null])).toThrow(TypeError)
+    expect(() => sumExpenses('no-es-arreglo')).toThrow(/arreglo/i)
+  })
+
+  it('el esquema del endpoint rechaza un gasto negativo o cero antes de registrarlo', () => {
+    const negativo = expenseSchema.safeParse({
+      projectId: 1,
+      activityName: 'Materiales',
+      expenseAmount: -250,
+    })
+    const cero = expenseSchema.safeParse({
+      projectId: 1,
+      activityName: 'Materiales',
+      expenseAmount: 0,
+    })
+
+    expect(negativo.success).toBe(false)
+    expect(cero.success).toBe(false)
+  })
+
+  it('el esquema acepta un gasto positivo válido', () => {
+    const result = expenseSchema.safeParse({
+      projectId: 1,
+      activityName: 'Materiales',
+      expenseAmount: 250.5,
+      motivo: 'Compra de cemento',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data.expenseAmount).toBe(250.5)
+  })
+})
+
+describe('Caso 8 · Proyecto sin gastos → acumulado 0', () => {
+  it('acumula 0 con lista vacía o sin argumento', () => {
+    expect(sumExpenses([])).toBe(0)
+    expect(sumExpenses()).toBe(0)
+  })
+
+  it('reporta presupuesto íntegro disponible y sin alerta', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 15000, gastos: [] })
+
+    expect(status.total_gastado).toBe(0)
+    expect(status.disponible).toBe(15000)
+    expect(status.porcentaje_uso).toBe(0)
+    expect(status.porcentaje_completado).toBe(0)
+    expect(status.alerta).toBeNull()
+    expect(status.alerta_nivel).toBe('SALUDABLE')
+  })
+})
+
+describe('Caso 9 · Umbral de advertencia al 80% del presupuesto', () => {
+  it('no advierte justo por debajo del 80%', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 10000, gastos: [7999.99] })
+
+    expect(status.alerta_nivel).toBe('PRECAUCION')
+  })
+
+  it('advierte exactamente en el 80% del presupuesto', () => {
+    const status = buildBudgetStatus({ presupuesto_total: 10000, gastos: [8000] })
+
+    expect(status.porcentaje_uso).toBe(0.8)
+    expect(status.alerta_nivel).toBe('ADVERTENCIA')
+    expect(status.alerta).toBe(ALERT_LEVELS.ADVERTENCIA.message)
+    expect(status.sobrecosto).toBe(false)
+  })
+
+  it('mantiene ADVERTENCIA entre el 80% y el 100%', () => {
+    expect(computeAlert(0.8, 1000).alerta_nivel).toBe('ADVERTENCIA')
+    expect(computeAlert(0.95, 1000).alerta_nivel).toBe('ADVERTENCIA')
+    expect(computeAlert(0.9999, 1000).alerta_nivel).toBe('ADVERTENCIA')
+  })
+
+  it('el umbral de advertencia declarado es 0.8', () => {
+    expect(ALERT_LEVELS.ADVERTENCIA.threshold).toBe(0.8)
+  })
+})

--- a/backend/tests/helpers/authTestApp.js
+++ b/backend/tests/helpers/authTestApp.js
@@ -1,0 +1,52 @@
+import express from 'express'
+import jwt from 'jsonwebtoken'
+
+import reportsRoutes from '../../src/routes/reportsRoutes.js'
+import projectRoutes from '../../src/routes/projectRoutes.js'
+import taskRoutes from '../../src/routes/taskRoutes.js'
+import companyRoutes from '../../src/routes/companyRoutes.js'
+
+export const JWT_SECRET = 'secreto-de-pruebas-hu31'
+process.env.JWT_SECRET = JWT_SECRET
+
+// Firma un JWT de prueba.
+export function signToken(overrides = {}, options = {}) {
+  return jwt.sign(
+    { id_usuario: 7, email: 'ivana@kontrol.gt', nombre_rol: 'user', ...overrides },
+    JWT_SECRET,
+    options
+  )
+}
+
+// Usuario SÍ pertenece a la empresa.
+export function companyMembership(rol_empresa, { activo = true, nombre = 'Empresa A' } = {}) {
+  return { rows: [{ id_rol_empresa: 1, rol_empresa, activo, nombre }] }
+}
+
+// Usuario NO pertenece a la empresa.
+export function noMembership() {
+  return { rows: [] }
+}
+
+// Filas genéricas para que el controller no responda 404.
+export function dbRows(rows = [{ id_proyecto: 10, id_reporte: 1 }]) {
+  return { rows, rowCount: rows.length }
+}
+
+// App con los routers reales bajo los mismos paths que producción.
+export function buildTestApp() {
+  const app = express()
+  app.use(express.json())
+
+  app.use('/api/reports', reportsRoutes)
+  app.use('/api/projects', projectRoutes)
+  app.use('/api/projects/:projectId/tasks', taskRoutes)
+  app.use('/api/companies', companyRoutes)
+
+  // eslint-disable-next-line no-unused-vars
+  app.use((err, req, res, next) => {
+    res.status(500).json({ success: false, message: err.message })
+  })
+
+  return app
+}

--- a/frontend/src/utils/sales.js
+++ b/frontend/src/utils/sales.js
@@ -1,0 +1,120 @@
+/**
+ * Lógica de cálculo del punto de venta (POS).
+ *
+ * Funciones puras, sin dependencias de Vue ni de red, para poder probarlas de
+ * forma aislada. Aquí vive el cálculo con mayor riesgo financiero del sistema:
+ * subtotales, descuentos, IVA y total de una venta. El orden de operaciones es
+ * siempre: subtotal → descuento → impuesto.
+ */
+
+/** IVA vigente en Guatemala (12%). */
+export const IVA_RATE = 0.12
+
+/**
+ * Redondea a dos decimales evitando los errores clásicos de coma flotante
+ * (p. ej. 1.005 → 1.01). Los valores no numéricos se tratan como 0.
+ */
+export function round2(value) {
+  const n = Number(value)
+  if (!Number.isFinite(n)) return 0
+  return Math.round((n + Number.EPSILON) * 100) / 100
+}
+
+/**
+ * Valida y normaliza el precio de un producto.
+ * Un precio nulo, vacío o no numérico produce un error controlado (nunca NaN).
+ */
+function toPrice(precio) {
+  if (precio === null || precio === undefined || precio === '') {
+    throw new Error('El producto no tiene precio.')
+  }
+  const n = Number(precio)
+  if (!Number.isFinite(n)) {
+    throw new Error('El precio del producto no es un número válido.')
+  }
+  if (n < 0) {
+    throw new Error('El precio del producto no puede ser negativo.')
+  }
+  return n
+}
+
+/**
+ * Valida y normaliza la cantidad de una línea.
+ * La cantidad 0 es válida (no suma al total); una cantidad negativa se rechaza.
+ */
+function toQuantity(cantidad) {
+  const n = Number(cantidad)
+  if (!Number.isFinite(n)) {
+    throw new Error('La cantidad no es un número válido.')
+  }
+  if (n < 0) {
+    throw new Error('La cantidad no puede ser negativa.')
+  }
+  return n
+}
+
+/**
+ * Normaliza un porcentaje (descuento o tasa) al rango [0, 100].
+ * Valores inválidos o negativos se tratan como 0.
+ */
+function clampPercent(percent) {
+  const n = Number(percent)
+  if (!Number.isFinite(n) || n < 0) return 0
+  if (n > 100) return 100
+  return n
+}
+
+/**
+ * Subtotal de una línea de venta (precio × cantidad), redondeado a 2 decimales.
+ * Acepta `{ precio, cantidad }` o un ítem del carrito `{ product, cantidad }`.
+ */
+export function lineTotal(line) {
+  const precio = toPrice(line?.precio ?? line?.precio_venta ?? line?.product?.precio_venta)
+  const cantidad = toQuantity(line?.cantidad)
+  return round2(precio * cantidad)
+}
+
+/**
+ * Suma de los subtotales de todas las líneas. Una venta vacía devuelve 0.
+ */
+export function calcSubtotal(lines) {
+  if (!Array.isArray(lines) || lines.length === 0) return 0
+  const sum = lines.reduce((acc, line) => acc + lineTotal(line), 0)
+  return round2(sum)
+}
+
+/**
+ * Aplica un descuento porcentual a un monto. El porcentaje se limita a [0, 100],
+ * por lo que un 100% deja el monto en 0 y el resultado nunca es negativo.
+ */
+export function applyDiscount(amount, discountPercent = 0) {
+  const base = round2(amount)
+  const pct = clampPercent(discountPercent)
+  return round2(Math.max(base * (1 - pct / 100), 0))
+}
+
+/**
+ * Calcula el desglose completo de una venta.
+ *
+ * Orden de operaciones (garantizado): el descuento se aplica sobre el subtotal
+ * y el impuesto se calcula sobre el subtotal ya descontado.
+ *
+ * @param {Array} lines Líneas de la venta (`{ precio, cantidad }`).
+ * @param {object} [options]
+ * @param {number} [options.discountPercent=0] Descuento porcentual [0, 100].
+ * @param {number} [options.taxRate=IVA_RATE] Tasa de impuesto (0.12 = 12%).
+ * @returns {{ subtotal:number, discount:number, taxableBase:number, tax:number, total:number }}
+ */
+export function calcSale(lines, { discountPercent = 0, taxRate = IVA_RATE } = {}) {
+  const subtotal = calcSubtotal(lines)
+
+  const pct = clampPercent(discountPercent)
+  const discount = round2(subtotal * (pct / 100))
+  const taxableBase = round2(Math.max(subtotal - discount, 0))
+
+  const rate = Number.isFinite(Number(taxRate)) && Number(taxRate) > 0 ? Number(taxRate) : 0
+  const tax = round2(taxableBase * rate)
+  const total = round2(Math.max(taxableBase + tax, 0))
+
+  return { subtotal, discount, taxableBase, tax, total }
+}

--- a/frontend/src/views/InventoryPage.vue
+++ b/frontend/src/views/InventoryPage.vue
@@ -384,6 +384,7 @@ import Pill from '../components/UI/Pill/Pill.vue'
 import Button from '../components/UI/Button/Button.vue'
 import ProductModal from '../components/inventory/ProductModal.vue'
 import { useAuthStore } from '@/stores/auth'
+import { lineTotal, calcSubtotal } from '@/utils/sales.js'
 
 const { t } = useI18n()
 const authStore = useAuthStore()
@@ -639,12 +640,10 @@ function clearSaleCart() {
 }
 
 function saleItemSubtotal(item) {
-  return Number(item.product.precio_venta) * Number(item.cantidad)
+  return lineTotal(item)
 }
 
-const saleTotal = computed(() =>
-  saleCart.value.reduce((acc, item) => acc + saleItemSubtotal(item), 0)
-)
+const saleTotal = computed(() => calcSubtotal(saleCart.value))
 
 const canSubmitSale = computed(() => saleCart.value.length > 0)
 

--- a/frontend/tests/sales.test.js
+++ b/frontend/tests/sales.test.js
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import {
+  IVA_RATE,
+  round2,
+  lineTotal,
+  calcSubtotal,
+  applyDiscount,
+  calcSale,
+} from '@/utils/sales.js'
+
+// Lógica del punto de venta (POS): es el cálculo con mayor riesgo financiero
+// del sistema, por eso cada caso de negocio se prueba de forma aislada.
+describe('POS · lógica de ventas', () => {
+  // 1. Total con un producto, cantidad 1.
+  it('calcula el total de un solo producto con cantidad 1', () => {
+    const lines = [{ precio: 100, cantidad: 1 }]
+    expect(calcSubtotal(lines)).toBe(100)
+    expect(calcSale(lines, { taxRate: 0 }).total).toBe(100)
+  })
+
+  // 2. Subtotal con múltiples líneas y cantidades distintas.
+  it('suma subtotales de múltiples líneas con cantidades distintas', () => {
+    const lines = [
+      { precio: 100, cantidad: 2 }, // 200
+      { precio: 55.5, cantidad: 3 }, // 166.5
+      { precio: 10, cantidad: 1 }, //  10
+    ]
+    expect(calcSubtotal(lines)).toBe(376.5)
+  })
+
+  // 3. Descuento porcentual aplicado correctamente.
+  it('aplica un descuento porcentual correctamente', () => {
+    expect(applyDiscount(100, 10)).toBe(90)
+    const { discount, total } = calcSale([{ precio: 100, cantidad: 1 }], {
+      discountPercent: 10,
+      taxRate: 0,
+    })
+    expect(discount).toBe(10)
+    expect(total).toBe(90)
+  })
+
+  // 4. Descuento del 100% → total 0, nunca negativo.
+  it('con descuento del 100% el total es 0 y nunca negativo', () => {
+    expect(applyDiscount(250, 100)).toBe(0)
+    expect(calcSale([{ precio: 250, cantidad: 2 }], { discountPercent: 100 }).total).toBe(0)
+    // Un porcentaje mayor a 100 se limita: sigue siendo 0, jamás negativo.
+    expect(applyDiscount(250, 150)).toBe(0)
+    expect(calcSale([{ precio: 250, cantidad: 2 }], { discountPercent: 150 }).total).toBe(0)
+  })
+
+  // 5. Cálculo de IVA (12%) sobre el subtotal ya descontado.
+  it('calcula el IVA (12%) sobre el subtotal ya descontado', () => {
+    // Sin descuento: 100 + 12% = 112.
+    const sinDescuento = calcSale([{ precio: 100, cantidad: 1 }], { taxRate: IVA_RATE })
+    expect(sinDescuento.tax).toBe(12)
+    expect(sinDescuento.total).toBe(112)
+
+    // Con 10% de descuento: base gravable 90, IVA 10.8, total 100.8.
+    const conDescuento = calcSale([{ precio: 100, cantidad: 1 }], {
+      discountPercent: 10,
+      taxRate: IVA_RATE,
+    })
+    expect(conDescuento.taxableBase).toBe(90)
+    expect(conDescuento.tax).toBe(10.8)
+    expect(conDescuento.total).toBe(100.8)
+  })
+
+  // 6. Orden de operaciones: descuento antes de impuesto.
+  it('aplica el descuento antes del impuesto', () => {
+    const { subtotal, discount, taxableBase, tax, total } = calcSale(
+      [{ precio: 200, cantidad: 1 }],
+      { discountPercent: 50, taxRate: IVA_RATE }
+    )
+    expect(subtotal).toBe(200)
+    expect(discount).toBe(100)
+    // El impuesto se calcula sobre la base ya descontada, no sobre el subtotal.
+    expect(taxableBase).toBe(subtotal - discount) // 100
+    expect(tax).toBe(round2(taxableBase * IVA_RATE)) // 12
+    // Si el IVA se aplicara antes del descuento, tax sería 24: se descarta.
+    expect(tax).not.toBe(round2(subtotal * IVA_RATE))
+    expect(total).toBe(112)
+  })
+
+  // 7. Cantidad cero → la línea no suma al total.
+  it('una línea con cantidad cero no suma al total', () => {
+    expect(lineTotal({ precio: 100, cantidad: 0 })).toBe(0)
+    const lines = [
+      { precio: 100, cantidad: 0 },
+      { precio: 50, cantidad: 2 },
+    ]
+    expect(calcSubtotal(lines)).toBe(100)
+  })
+
+  // 8. Producto sin precio o null → error controlado, no NaN.
+  it('rechaza un producto sin precio con error controlado (no NaN)', () => {
+    expect(() => lineTotal({ precio: null, cantidad: 1 })).toThrow()
+    expect(() => lineTotal({ precio: undefined, cantidad: 1 })).toThrow()
+    expect(() => lineTotal({ precio: 'abc', cantidad: 1 })).toThrow()
+    expect(() => lineTotal({ precio: -5, cantidad: 1 })).toThrow()
+    expect(() => calcSubtotal([{ precio: null, cantidad: 1 }])).toThrow()
+  })
+
+  // 9. Redondeo a dos decimales.
+  it('redondea el resultado a dos decimales', () => {
+    expect(round2(1.005)).toBe(1.01)
+    expect(round2(2.675)).toBe(2.68)
+    // 10.10 + 12% IVA = 11.312 → 11.31.
+    expect(calcSale([{ precio: 10.1, cantidad: 1 }], { taxRate: IVA_RATE }).total).toBe(11.31)
+    expect(lineTotal({ precio: 33.333, cantidad: 3 })).toBe(100)
+  })
+
+  // 10. Venta vacía → total 0.
+  it('una venta vacía tiene total 0', () => {
+    expect(calcSubtotal([])).toBe(0)
+    expect(calcSale([]).total).toBe(0)
+    expect(calcSubtotal(null)).toBe(0)
+  })
+
+  // 11. Cantidad negativa → rechazo por validación.
+  it('rechaza cantidades negativas por validación', () => {
+    expect(() => lineTotal({ precio: 100, cantidad: -1 })).toThrow()
+    expect(() => lineTotal({ precio: 100, cantidad: 'x' })).toThrow()
+    expect(() => calcSubtotal([{ precio: 100, cantidad: -2 }])).toThrow()
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.10",
         "cross-env": "^7.0.3",
+        "supertest": "^7.2.2",
         "vitest": "^4.1.10"
       },
       "engines": {
@@ -874,6 +875,19 @@
         "win32"
       ]
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@one-ini/wasm": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
@@ -888,6 +902,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1765,6 +1789,13 @@
       "version": "1.1.1",
       "license": "MIT"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1796,6 +1827,13 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2015,6 +2053,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -2023,6 +2074,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/concurrently": {
@@ -2096,6 +2157,13 @@
       "version": "1.0.7",
       "license": "MIT"
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "license": "MIT",
@@ -2165,6 +2233,16 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "license": "MIT",
@@ -2188,6 +2266,17 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dompurify": {
@@ -2420,6 +2509,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -2569,6 +2674,13 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2647,6 +2759,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "license": "MIT",
@@ -2655,6 +2784,24 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -2881,8 +3028,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
-      "version": "2.0.2",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3658,6 +3823,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -4485,6 +4660,90 @@
         "node": ">=8"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -5026,6 +5285,13 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.3",


### PR DESCRIPTION
## Summary
Release of `develop` into `main`. This version adds the first automated unit-test suite for the three core flows (POS sales, budget control, auth & permissions), extracts the business logic behind those flows into testable pure-function modules, and runs everything through the CI workflow on every PR into `main` / `develop`.

No behavioural change is intended for end users: the refactors are logic extractions with the same math and the same outputs, now covered by tests.

## What is included

### New test suites (48 test cases)
| Suite | Cases | Scope |
|---|---|---|
| `frontend/tests/sales.test.js` | 11 | POS: line totals, subtotal, discounts, IVA, full sale calculation |
| `backend/tests/budgetCalculations.test.js` | 27 | Expense accumulation, usage ratio/percentage, overrun alert levels, budget status |
| `backend/tests/authz.controller.test.js` | 10 | Controller-level authentication and permission checks (HU-31) |

### Refactors (behaviour-preserving)
- `frontend/src/utils/sales.js` (new) — POS math extracted out of the view: `IVA_RATE`, `round2`, `lineTotal`, `calcSubtotal`, `applyDiscount`, `calcSale`.
- `frontend/src/views/InventoryPage.vue` — now consumes `lineTotal` / `calcSubtotal` instead of inline arithmetic.
- `backend/src/utils/budgetCalculations.js` (new) — budget math extracted out of the controller: `ALERT_LEVELS`, `sumExpenses`, `calculateUsageRatio`, `calculateUsagePercentage`, `computeAlert`, `buildBudgetStatus`.
- `backend/src/controllers/budgetController.js` — slimmed down (40 lines removed) and delegates to the new utils module.

### Test infrastructure
- `backend/tests/helpers/authTestApp.js` — builds an app instance and signs test tokens for controller-level auth tests.
- `supertest` added as a backend dev dependency.

### Merged pull requests
- #78 — `feat/unit-test-pos`: POS logic extraction + 11 unit tests
- #79 — `test/auth-permisos-controller`: auth/permission controller tests + test app helper
- #80 — `test/budget-expenses`: budget math extraction + accumulated spend and overrun alert tests

## Diff overview
```
backend/package.json                        |   1 +
backend/src/controllers/budgetController.js |  40 +----
backend/src/utils/budgetCalculations.js     | 107 +++++++++++
backend/tests/authz.controller.test.js      | 167 +++++++++++++++++
backend/tests/budgetCalculations.test.js    | 227 +++++++++++++++++++++++
backend/tests/helpers/authTestApp.js        |  52 ++++++
frontend/src/utils/sales.js                 | 120 +++++++++++++
frontend/src/views/InventoryPage.vue        |   7 +-
frontend/tests/sales.test.js                | 125 +++++++++++++
package-lock.json                           | 268 +++++++++++++++++++++++++++-
10 files changed, 1078 insertions(+), 36 deletions(-)
```
10 commits ahead of `main`.

## Type of change
- [ ] `feat` – new feature
- [ ] `fix` – bug fix
- [x] `refactor` – code change that is neither a fix nor a feature
- [ ] `docs` – documentation only
- [x] `test` – adding or updating tests
- [x] `chore` – build, config, dependencies

## Related issue / task
HU-31 (auth & permissions tests). Tarea 3 — pruebas automatizadas.

## Testing
CI (`.github/workflows/ci.yml`) runs on every PR into `main` / `develop`:
- `backend-tests`: `npm ci` + `npm run test:coverage -w backend`, coverage uploaded as artifact.
- `frontend-tests`: `npm ci` + `npm run test:coverage -w frontend`, coverage uploaded as artifact, plus a production build check (`npm run build -w frontend`).

CI passed on all three source PRs (#78, #79, #80) before merging into `develop`, and runs again on this PR.

- [x] Tested manually (Postman / browser)
- [x] Unit tests pass
- [x] No regressions on existing endpoints

## Deployment notes
- No new environment variables, no migrations, no config changes.
- New dev dependency only (`supertest`); production runtime dependencies are unchanged.
- Package versions remain at `1.0.0` — no version bump or tag is part of this PR.

## Checklist
- [x] Branch follows naming convention (`type/short-description`)
- [x] Commits follow Conventional Commits (`type(scope): message`)
- [x] No secrets or credentials committed
- [x] `password_hash` or sensitive fields are not exposed in responses
- [x] `.env.example` updated if new env vars were added (none added)
