### PR TITLE
feat(styles): design tokens and base theme (SCRUM-13 / HU-32)

### DIFF
--- a/frontend/globals.css
+++ b/frontend/globals.css
@@ -1,32 +1,61 @@
+/**
+ * Kontrol — hoja global.
+ *
+ * Desde SCRUM-13 este archivo NO define valores de marca: los tokens viven en
+ * `src/styles/theme.css`. Aquí solo queda:
+ *   1. la capa de compatibilidad legacy (alias → tokens),
+ *   2. el reset mínimo del documento,
+ *   3. estilos base heredados de la landing.
+ */
+
+@import './src/styles/theme.css';
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/**
+ * Capa de compatibilidad (SCRUM-13, punto 3 del alcance).
+ *
+ * Estas variables sin prefijo son las que ya consumían las pantallas
+ * existentes (~330 usos de `var(--Primary)`, `var(--Text)`, …). Se conservan
+ * como ALIAS de los tokens nuevos para que nada se rompa mientras avanza la
+ * migración de SCRUM-14..17.
+ *
+ * ⚠️ Congeladas: no agregar variables nuevas a esta lista. Todo código nuevo
+ * consume `var(--k-*)` directamente. Esta capa desaparece cuando no queden
+ * consumidores.
+ */
 :root {
-  --Primary: #caa860;
-  --Primary2: #b27f2a;
-  --Secondary: #886911;
-  --Tertiary: #12120e;
-  --Border: #312713;
-  --PillBack: #120f07;
-  --Text: #ffffff;
-  --Background: rgba(0, 0, 0, 0.92);
-  --Background2: #120f07;
-  --Background3: #282825;
-  --Success: rgb(15, 77, 15);
-  --Error: rgb(128, 13, 13);
-  --Warning: rgb(120, 80, 10);
+  --Primary: var(--k-color-primary);
+  --Primary2: var(--k-color-primary-2);
+  --Secondary: var(--k-color-secondary);
+  --Tertiary: var(--k-color-tertiary);
+  --Border: var(--k-color-border);
+  --PillBack: var(--k-color-pill-back);
+  --Text: var(--k-color-text);
+  --Background: var(--k-color-bg);
+  --Background2: var(--k-color-bg-2);
+  --Background3: var(--k-color-bg-3);
+  --Success: var(--k-color-success);
+  --Error: var(--k-color-error);
+  --Warning: var(--k-color-warning);
 
   /* Texto secundario */
-  --TextMuted: #8a8070;
-  --TextDim: #5a5040;
-  --TextPlaceholder: #4a4030;
+  --TextMuted: var(--k-text-muted);
+  --TextDim: var(--k-text-dim);
+  --TextPlaceholder: var(--k-text-placeholder);
 
   /* Estados visuales */
-  --ErrorText: #e05252;
-  --SuccessText: #48c774;
+  --ErrorText: var(--k-state-error-text);
+  --SuccessText: var(--k-state-success-text);
 
   /* Formularios */
-  --InputBg: rgba(255, 255, 255, 0.04);
-  --InputFocusBg: rgba(202, 168, 96, 0.05);
-  --BtnText: #0e0c08;
+  --InputBg: var(--k-form-input-bg);
+  --InputFocusBg: var(--k-form-input-focus-bg);
+  --BtnText: var(--k-form-btn-text);
 }
+
 html,
 body,
 #app {
@@ -39,29 +68,33 @@ body,
 html {
   scrollbar-gutter: stable;
 }
+
+/* Estilos heredados de la landing. Usan Alfa Slab One / DM Sans, que no forman
+   parte de la identidad v2; se migran en SCRUM-14..17. */
 .hero-title {
   color: var(--Text);
-  font-family: "Alfa Slab One";
+  font-family: 'Alfa Slab One';
   letter-spacing: 5px;
   font-size: clamp(2rem, 6vw, 6rem);
   margin-bottom: 20px;
 }
 
 p {
-  font-family: "DM Sans";
+  font-family: 'DM Sans';
   font-size: clamp(0.95rem, 1.5vw, 1.2rem);
   color: var(--Text);
   z-index: 20;
 }
 
 .sub-title {
-  font-family: "Alfa Slab One";
+  font-family: 'Alfa Slab One';
   letter-spacing: 2px;
   font-size: clamp(1.5rem, 3.5vw, 3rem);
   text-align: center;
   color: var(--Text);
   z-index: 20;
 }
+
 @media screen and (max-width: 500px) {
   .hero-title {
     font-size: 2em;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,11 +7,16 @@
     <title>Kontrol</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- Identidad v2 (SCRUM-13): Playfair Display (display), Manrope (UI),
+         JetBrains Mono (técnica). El resto son familias legacy pendientes de
+         migrar en SCRUM-14..17. -->
     <link
-      href="https://fonts.googleapis.com/css2?family=Alfa+Slab+One&family=Archivo+Black&family=Bungee&family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Tenor+Sans&family=Titan+One&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Alfa+Slab+One&family=Archivo+Black&family=Bungee&family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Manrope:wght@200..800&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Tenor+Sans&family=Titan+One&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./globals.css" />
+    <!-- globals.css se importa desde src/main.js para que pase por el pipeline
+         de PostCSS/Tailwind. No volver a enlazarlo aquí: se cargaría dos veces
+         y la copia del <link> no resolvería @import ni las directivas. -->
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,10 @@
     "@vitejs/plugin-vue": "^5.1.0",
     "@vitest/coverage-v8": "^4.1.10",
     "@vue/test-utils": "^2.4.11",
+    "autoprefixer": "^10.5.4",
     "happy-dom": "^20.10.6",
+    "postcss": "^8.5.26",
+    "tailwindcss": "^3.4.19",
     "vite": "^6.0.0",
     "vitest": "^4.1.10"
   }

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,0 +1,14 @@
+/**
+ * Kontrol — PostCSS (SCRUM-13 / HU-32)
+ *
+ * `postcss-import` debe ir antes que Tailwind para que el `@import` de
+ * `src/styles/theme.css` en `globals.css` se resuelva en build time.
+ * Viene incluido con Tailwind, no requiere dependencia adicional.
+ */
+export default {
+  plugins: {
+    'postcss-import': {},
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/composables/useTheme.js
+++ b/frontend/src/composables/useTheme.js
@@ -1,0 +1,82 @@
+import { readonly, ref } from 'vue'
+
+/**
+ * Kontrol — control de tema (SCRUM-13 / HU-32, punto 4 del alcance).
+ *
+ * Escribe `data-theme` en `<html>`, que es lo que leen los tokens de
+ * `src/styles/theme.css`. Preferencia persistida en localStorage.
+ *
+ * Estado actual: SCRUM-12 definió únicamente la identidad "Luxury Dark".
+ * El tema claro está declarado pero sin overrides, así que seleccionarlo
+ * hereda el oscuro. El mecanismo es funcional; faltan los valores de marca.
+ * Ver el TODO(SCRUM-12) en `theme.css`.
+ */
+
+const STORAGE_KEY = 'kontrol:theme'
+const THEMES = ['dark', 'light']
+const DEFAULT_THEME = 'dark'
+
+const current = ref(DEFAULT_THEME)
+
+function readStored() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    return THEMES.includes(stored) ? stored : null
+  } catch {
+    // Safari en modo privado y algunos entornos de test lanzan al tocar
+    // localStorage. La preferencia no es crítica: se cae al default.
+    return null
+  }
+}
+
+function persist(theme) {
+  try {
+    localStorage.setItem(STORAGE_KEY, theme)
+  } catch {
+    // idem: sin persistencia, el tema sigue aplicándose en la sesión actual.
+  }
+}
+
+function apply(theme) {
+  current.value = theme
+  document.documentElement.setAttribute('data-theme', theme)
+}
+
+/** Resuelve la preferencia: guardada > sistema > default. */
+function resolveInitial() {
+  const stored = readStored()
+  if (stored) return stored
+
+  const prefersLight =
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-color-scheme: light)').matches
+
+  return prefersLight ? 'light' : DEFAULT_THEME
+}
+
+export function useTheme() {
+  /** Llamar una vez al arrancar la app, antes del primer render. */
+  function initTheme() {
+    apply(resolveInitial())
+  }
+
+  function setTheme(theme) {
+    if (!THEMES.includes(theme)) {
+      throw new Error(`Tema desconocido: "${theme}". Válidos: ${THEMES.join(', ')}`)
+    }
+    apply(theme)
+    persist(theme)
+  }
+
+  function toggleTheme() {
+    setTheme(current.value === 'dark' ? 'light' : 'dark')
+  }
+
+  return {
+    theme: readonly(current),
+    availableThemes: THEMES,
+    initTheme,
+    setTheme,
+    toggleTheme,
+  }
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,7 +3,11 @@ import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 import { i18n } from './locales/index.js'
+import { useTheme } from './composables/useTheme.js'
 import '../globals.css'
+
+// Antes de montar, para que el primer render ya tenga el tema resuelto.
+useTheme().initTheme()
 
 const app = createApp(App)
 

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -1,0 +1,135 @@
+/**
+ * Kontrol — Design tokens (SCRUM-13 / HU-32)
+ *
+ * Fuente única de verdad del tema. Traducción a código de la guía de estilo
+ * aprobada en SCRUM-12; los nombres siguen las láminas de Figma documentadas
+ * en `docs/design-tokens-figma.md`.
+ *
+ * Reglas:
+ *  - Todo valor de marca (color, tipografía, espaciado, radio, sombra) vive aquí.
+ *    Ningún otro archivo debería declarar literales de marca.
+ *  - Consumir siempre `var(--k-*)`. Las variables sin prefijo (`--Primary`,
+ *    `--Text`, …) son alias legacy definidos en `globals.css` y están congelados:
+ *    existen para que las pantallas aún no migradas sigan funcionando.
+ *  - Tailwind lee estos mismos tokens (ver `tailwind.config.js`), así que las
+ *    clases utilitarias y el CSS plano no pueden divergir.
+ */
+
+:root,
+[data-theme='dark'] {
+  /* ── color/ ─────────────────────────────────────────────── */
+  --k-color-primary: #caa860;
+  --k-color-primary-2: #b27f2a;
+  --k-color-secondary: #886911;
+  --k-color-tertiary: #12120e;
+  --k-color-border: #312713;
+  --k-color-pill-back: #120f07;
+  --k-color-bg: rgba(0, 0, 0, 0.92);
+  --k-color-bg-2: #120f07;
+  --k-color-bg-3: #282825;
+  --k-color-text: #faf8f5;
+  --k-color-text-muted: #8a8070; /* distinto de --k-text-muted: gris neutro, no cálido */
+  --k-color-success: rgb(15, 77, 15);
+  --k-color-error: rgb(128, 13, 13);
+  --k-color-warning: rgb(120, 80, 10);
+
+  /* Triplets RGB de los colores que se usan con transparencia (glows,
+     tintes, overlays). Consumir como `rgba(var(--k-color-primary-rgb), 0.4)`
+     — evita repetir el literal del dorado por todo el código. */
+  --k-color-primary-rgb: 202, 168, 96;
+  --k-color-error-rgb: 224, 82, 82;
+  --k-color-black-rgb: 0, 0, 0;
+  --k-color-white-rgb: 255, 255, 255;
+
+  /* ── text/ ──────────────────────────────────────────────── */
+  --k-text-soft: #cfc9bf;
+  --k-text-muted: #989083;
+  --k-text-dim: #6e6558;
+  --k-text-faint: #565045;
+  --k-text-placeholder: #4a4030;
+
+  /* ── visualStates/ ──────────────────────────────────────── */
+  --k-state-error-text: #e05252;
+  --k-state-success-text: #48c774;
+
+  /* ── forms/ ─────────────────────────────────────────────── */
+  --k-form-input-bg: rgba(255, 255, 255, 0.04);
+  --k-form-input-focus-bg: rgba(202, 168, 96, 0.05);
+  --k-form-btn-text: #0e0c08;
+
+  /* ── font/ ──────────────────────────────────────────────── */
+  --k-font-display: 'Playfair Display', Georgia, serif;
+  --k-font-sans: 'Manrope', 'DM Sans', system-ui, sans-serif;
+  --k-font-mono: 'JetBrains Mono', ui-monospace, monospace;
+
+  --k-font-size-display: 42px;
+  --k-font-size-heading-1: 24px;
+  /* body-large: la lámina de Figma define este nivel pero ninguna fuente le
+     asigna px (design-system.md solo escala 42/24/14/11). 16px es un supuesto
+     de implementación — confirmar con Diseño antes de propagarlo. */
+  --k-font-size-body-large: 16px;
+  --k-font-size-body-main: 14px;
+  --k-font-size-caption: 11px;
+
+  --k-font-weight-regular: 400;
+  --k-font-weight-medium: 500;
+  --k-font-weight-semibold: 600;
+  --k-font-weight-bold: 700;
+
+  /* ── spacing/ — rejilla 8pt, nomenclatura Figma (space-7 = 48px) ── */
+  --k-space-1: 4px;
+  --k-space-2: 8px;
+  --k-space-3: 12px;
+  --k-space-4: 16px;
+  --k-space-5: 24px;
+  --k-space-6: 32px;
+  --k-space-7: 48px;
+
+  /* ── radius/ ────────────────────────────────────────────── */
+  --k-radius-sm: 4px;
+  --k-radius-md: 8px;
+  --k-radius-lg: 12px;
+  --k-radius-xl: 24px;
+  --k-radius-pill: 999px;
+
+  /* ── shadow/ — pensadas para fondo oscuro ───────────────── */
+  --k-shadow-card: 0 4px 20px 0 rgba(0, 0, 0, 0.5);
+  --k-shadow-glow: 0 0 15px 5px rgba(202, 168, 96, 0.5);
+  --k-shadow-modal: 0 10px 40px 0 rgba(0, 0, 0, 0.8);
+
+  /* ── estados de interacción ─────────────────────────────── */
+  --k-state-hover-brightness: 1.15;
+  --k-state-active-scale: 0.98;
+  --k-state-disabled-opacity: 0.3;
+  --k-focus-ring-width: 2px;
+  --k-focus-ring-offset: 2px;
+  --k-focus-ring: var(--k-focus-ring-width) solid var(--k-color-primary);
+
+  /* ── iconografía ────────────────────────────────────────── */
+  --k-icon-stroke: 1.5px;
+  --k-icon-size: 24px;
+
+  /* ── accesibilidad ──────────────────────────────────────── */
+  --k-target-min-size: 40px;
+}
+
+/**
+ * TODO(SCRUM-12): paleta clara pendiente de Diseño.
+ *
+ * SCRUM-12 definió únicamente la identidad "Luxury Dark"; no existe paleta
+ * clara aprobada. El mecanismo de theming queda operativo (`[data-theme]` y
+ * `prefers-color-scheme`), pero sin overrides: el tema claro hereda el oscuro
+ * a propósito, para no inventar colores de marca sin aprobación.
+ *
+ * Cuando Diseño entregue la paleta, basta redeclarar aquí los tokens que
+ * cambien. Ningún consumidor necesita tocarse.
+ */
+[data-theme='light'] {
+  /* overrides del tema claro van aquí */
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) {
+    /* idem: sin overrides hasta que exista paleta clara aprobada */
+  }
+}

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -38,6 +38,7 @@
      — evita repetir el literal del dorado por todo el código. */
   --k-color-primary-rgb: 202, 168, 96;
   --k-color-error-rgb: 224, 82, 82;
+  --k-color-success-rgb: 72, 199, 116;
   --k-color-black-rgb: 0, 0, 0;
   --k-color-white-rgb: 255, 255, 255;
 

--- a/frontend/src/views/LoginView.css
+++ b/frontend/src/views/LoginView.css
@@ -408,6 +408,13 @@
   border: 1px solid var(--k-state-error-text);
   color: var(--k-state-error-text);
 }
+/* El template ya usaba esta variante para el banner de invitación, pero nunca
+   tuvo reglas: heredaba solo el padding y quedaba sin color. */
+.login-banner--success {
+  background: rgba(var(--k-color-success-rgb), 0.12);
+  border: 1px solid var(--k-state-success-text);
+  color: var(--k-state-success-text);
+}
 
 /* ── Responsive ──
    Solo geometría: no hay valores de marca en los breakpoints. Los tamaños de

--- a/frontend/src/views/LoginView.css
+++ b/frontend/src/views/LoginView.css
@@ -1,10 +1,20 @@
+/**
+ * LoginView — pantalla piloto de la identidad v2 (SCRUM-13).
+ *
+ * Consume exclusivamente los tokens de `src/styles/theme.css`. Sirve de
+ * referencia para la migración del resto de pantallas (SCRUM-14..17): si algo
+ * aquí necesitó un literal, está comentado y explica por qué.
+ *
+ * No se tocó el layout: solo valores. Cualquier diferencia visual respecto de
+ * la versión anterior es adopción intencional de la guía de estilo.
+ */
 
 /* ── Layout ── */
 .login-page {
   position: relative;
   min-height: 100vh;
   display: flex;
-  font-family: 'DM Sans', sans-serif;
+  font-family: var(--k-font-sans);
 }
 
 .login-layout {
@@ -36,9 +46,12 @@
 .login-logo-img {
   width: 460px;
   max-width: 100%;
-  filter: drop-shadow(0 0 90px rgba(202, 168, 96, 0.45));
+  filter: drop-shadow(0 0 90px rgba(var(--k-color-primary-rgb), 0.45));
 }
-.login-logo-3d { width: 460px; max-width: 100%; }
+.login-logo-3d {
+  width: 460px;
+  max-width: 100%;
+}
 
 /* ── Panel formulario (derecha) ── */
 .login-form-panel {
@@ -50,23 +63,26 @@
   width: 75%;
   min-width: 520px;
   min-height: 100vh;
-  padding: 3rem 5rem;
+  padding: var(--k-space-7) 5rem;
   box-sizing: border-box;
+  /* El degradado de fondo es composición, no un color de paleta: los stops
+     salen de --k-color-tertiary hacia negro. SCRUM-12 no define tokens de
+     degradado; si Diseño los formaliza, se sustituyen aquí. */
   background:
-    radial-gradient(120% 80% at 0% 50%, rgba(202, 168, 96, 0.10), transparent 55%),
-    linear-gradient(180deg, #0c0c0c 0%, #050505 100%);
+    radial-gradient(120% 80% at 0% 50%, rgba(var(--k-color-primary-rgb), 0.1), transparent 55%),
+    linear-gradient(180deg, var(--k-color-tertiary) 0%, rgb(var(--k-color-black-rgb)) 100%);
   border-right: none;
-  border-radius: 22px 0 0 22px;
-  box-shadow: -30px 0 80px rgba(0, 0, 0, 0.55), inset 1px 0 0 rgba(255, 255, 255, 0.04);
+  border-radius: var(--k-radius-xl) 0 0 var(--k-radius-xl);
+  box-shadow:
+    -30px 0 80px rgba(var(--k-color-black-rgb), 0.55),
+    inset 1px 0 0 rgba(var(--k-color-white-rgb), 0.04);
 }
-
-
 
 /* ── Card ── */
 .login-card {
   width: 100%;
   max-width: 620px;
-  background: #111111;
+  background: var(--k-color-tertiary);
   border: none;
   border-radius: 0;
   padding: 0;
@@ -74,179 +90,277 @@
 }
 
 .login-title {
-  font-size: 2rem;
-  font-weight: 700;
-  color: var(--Text);
-  margin: 0 0 1.5rem;
+  font-family: var(--k-font-display);
+  font-size: var(--k-font-size-heading-1);
+  font-weight: var(--k-font-weight-bold);
+  color: var(--k-color-text);
+  margin: 0 0 var(--k-space-5);
 }
 
 /* ── Campos ── */
 .login-field {
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
-  margin-bottom: 1rem;
+  gap: var(--k-space-1);
+  margin-bottom: var(--k-space-4);
 }
 
 .login-field-label {
-  font-size: 0.80rem;
-  color: var(--TextMuted);
+  font-size: var(--k-font-size-caption);
+  color: var(--k-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.07em;
 }
 
-.login-input-wrap { position: relative; }
+.login-input-wrap {
+  position: relative;
+}
 
 .login-input {
   width: 100%;
+  min-height: var(--k-target-min-size);
   box-sizing: border-box;
-  padding: 0.72rem 2.4rem 0.72rem 0.85rem;
-  background: var(--InputBg);
-  border: 1px solid var(--Border);
-  border-radius: 6px;
-  color: var(--Text);
-  font-size: 0.92rem;
-  font-family: 'DM Sans', sans-serif;
+  padding: var(--k-space-3) var(--k-space-7) var(--k-space-3) var(--k-space-3);
+  background: var(--k-form-input-bg);
+  border: 1px solid var(--k-color-border);
+  border-radius: var(--k-radius-sm);
+  color: var(--k-color-text);
+  font-size: var(--k-font-size-body-main);
+  font-family: var(--k-font-sans);
   outline: none;
-  transition: border-color 0.2s, background 0.2s;
+  transition:
+    border-color 0.2s,
+    background 0.2s;
 }
-.login-input::placeholder { color: var(--TextPlaceholder); }
-.login-input:focus        { border-color: var(--Primary); background: var(--InputFocusBg); }
-.login-input--error       { border-color: var(--ErrorText) !important; }
+.login-input::placeholder {
+  color: var(--k-text-placeholder);
+}
+.login-input:focus {
+  border-color: var(--k-color-primary);
+  background: var(--k-form-input-focus-bg);
+}
+.login-input:focus-visible {
+  outline: var(--k-focus-ring);
+  outline-offset: var(--k-focus-ring-offset);
+}
+.login-input--error {
+  border-color: var(--k-state-error-text) !important;
+}
 
 .login-input-icon {
   position: absolute;
-  right: 0.72rem;
+  right: var(--k-space-3);
   top: 50%;
   transform: translateY(-50%);
-  color: var(--TextDim);
+  color: var(--k-text-dim);
   pointer-events: none;
 }
-.login-input-icon--btn { pointer-events: auto; cursor: pointer; }
+.login-input-icon--btn {
+  pointer-events: auto;
+  cursor: pointer;
+}
+.login-input-icon--btn:focus-visible {
+  outline: var(--k-focus-ring);
+  outline-offset: var(--k-focus-ring-offset);
+  border-radius: var(--k-radius-sm);
+}
 
-.login-field-error { font-size: 0.76rem; color: var(--ErrorText); }
+.login-field-error {
+  font-size: var(--k-font-size-caption);
+  color: var(--k-state-error-text);
+}
 
 /* ── Remember + Forgot ── */
 .login-row-extras {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1.2rem;
+  margin-bottom: var(--k-space-4);
 }
 
 .login-remember {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
-  font-size: 0.83rem;
-  color: var(--TextMuted);
+  gap: var(--k-space-2);
+  font-size: var(--k-font-size-body-main);
+  color: var(--k-text-muted);
   cursor: pointer;
-  accent-color: var(--Primary);
+  accent-color: var(--k-color-primary);
+}
+.login-remember input:focus-visible {
+  outline: var(--k-focus-ring);
+  outline-offset: var(--k-focus-ring-offset);
 }
 
 .login-forgot {
-  font-size: 0.83rem;
-  color: var(--Primary);
+  font-size: var(--k-font-size-body-main);
+  color: var(--k-color-primary);
   text-decoration: none;
 }
-.login-forgot:hover { text-decoration: underline; }
+.login-forgot:hover {
+  text-decoration: underline;
+}
+.login-forgot:focus-visible {
+  outline: var(--k-focus-ring);
+  outline-offset: var(--k-focus-ring-offset);
+  border-radius: var(--k-radius-sm);
+}
 
 /* ── Botón principal ── */
 .login-btn-primary {
   position: relative;
   width: 100%;
-  padding: 0.95rem;
+  min-height: var(--k-target-min-size);
+  padding: var(--k-space-3);
+  /* Degradado de marca: brillo superior + rampa dorada. Los stops intermedios
+     no son tokens de paleta; se derivan del dorado primario. */
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0) 45%),
-    linear-gradient(180deg, #f3d489 0%, #d6a955 45%, #b8862f 100%);
-  color: #ffffff;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
-  font-weight: 700;
-  font-size: 0.98rem;
-  font-family: 'DM Sans', sans-serif;
-  border: 1px solid rgba(255, 220, 150, 0.35);
-  border-radius: 8px;
+    linear-gradient(
+      180deg,
+      rgba(var(--k-color-white-rgb), 0.18),
+      rgba(var(--k-color-white-rgb), 0) 45%
+    ),
+    linear-gradient(
+      180deg,
+      #f3d489 0%,
+      var(--k-color-primary) 45%,
+      var(--k-color-primary-2) 100%
+    );
+  color: var(--k-form-btn-text);
+  font-weight: var(--k-font-weight-bold);
+  font-size: var(--k-font-size-body-large);
+  font-family: var(--k-font-sans);
+  border: 1px solid rgba(var(--k-color-primary-rgb), 0.35);
+  border-radius: var(--k-radius-sm);
   cursor: pointer;
   letter-spacing: 0.04em;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
+  gap: var(--k-space-2);
   box-shadow:
-    0 10px 30px rgba(202, 168, 96, 0.35),
-    inset 0 1px 0 rgba(255, 255, 255, 0.45),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.25);
-  transition: transform 0.15s ease, box-shadow 0.2s ease, filter 0.2s ease;
+    0 10px 30px rgba(var(--k-color-primary-rgb), 0.35),
+    inset 0 1px 0 rgba(var(--k-color-white-rgb), 0.45),
+    inset 0 -1px 0 rgba(var(--k-color-black-rgb), 0.25);
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.2s ease,
+    filter 0.2s ease;
   overflow: hidden;
 }
 .login-btn-primary::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(110deg, transparent 30%, rgba(255, 255, 255, 0.35) 50%, transparent 70%);
+  background: linear-gradient(
+    110deg,
+    transparent 30%,
+    rgba(var(--k-color-white-rgb), 0.35) 50%,
+    transparent 70%
+  );
   transform: translateX(-100%);
   transition: transform 0.6s ease;
   pointer-events: none;
 }
 .login-btn-primary:hover:not(:disabled) {
-  transform: translateY(-1px);
-  filter: brightness(1.05);
-  box-shadow:
-    0 14px 36px rgba(202, 168, 96, 0.5),
-    inset 0 1px 0 rgba(255, 255, 255, 0.5),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.25);
+  filter: brightness(var(--k-state-hover-brightness));
+  box-shadow: var(--k-shadow-glow);
 }
-.login-btn-primary:hover:not(:disabled)::after { transform: translateX(100%); }
-.login-btn-primary:disabled { opacity: 0.55; cursor: not-allowed; }
+.login-btn-primary:hover:not(:disabled)::after {
+  transform: translateX(100%);
+}
+.login-btn-primary:active:not(:disabled) {
+  transform: scale(var(--k-state-active-scale));
+}
+.login-btn-primary:focus-visible {
+  outline: var(--k-focus-ring);
+  outline-offset: var(--k-focus-ring-offset);
+}
+.login-btn-primary:disabled {
+  opacity: var(--k-state-disabled-opacity);
+  cursor: not-allowed;
+}
 
 .login-spinner {
   width: 15px;
   height: 15px;
-  border: 2px solid rgba(14, 12, 8, 0.25);
-  border-top-color: var(--BtnText);
-  border-radius: 50%;
+  border: 2px solid rgba(var(--k-color-black-rgb), 0.25);
+  border-top-color: var(--k-form-btn-text);
+  border-radius: var(--k-radius-pill);
   animation: login-spin 0.65s linear infinite;
 }
-@keyframes login-spin { to { transform: rotate(360deg); } }
+@keyframes login-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 
 /* ── Divisor ── */
 .login-divider {
   display: flex;
   align-items: center;
-  gap: 0.7rem;
-  margin: 1.2rem 0;
+  gap: var(--k-space-3);
+  margin: var(--k-space-4) 0;
 }
 .login-divider::before,
-.login-divider::after { content: ''; flex: 1; height: 1px; background: var(--Border); }
-.login-divider span   { font-size: 0.78rem; color: var(--TextDim); }
+.login-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--k-color-border);
+}
+.login-divider span {
+  font-size: var(--k-font-size-caption);
+  color: var(--k-text-dim);
+}
 
 /* ── OAuth ── */
-.login-oauth-row { display: flex; gap: 0.7rem; margin-bottom: 1.1rem; }
+.login-oauth-row {
+  display: flex;
+  gap: var(--k-space-3);
+  margin-bottom: var(--k-space-4);
+}
 
 .login-btn-oauth {
   flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  padding: 0.75rem 0.6rem;
+  gap: var(--k-space-2);
+  min-height: var(--k-target-min-size);
+  padding: var(--k-space-3) var(--k-space-2);
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0)),
-    linear-gradient(180deg, #1a1a1a, #0e0e0e);
-  border: 1px solid var(--Border);
-  border-radius: 8px;
-  color: #ffffff;
-  font-size: 0.82rem;
-  font-family: 'DM Sans', sans-serif;
+    linear-gradient(
+      180deg,
+      rgba(var(--k-color-white-rgb), 0.04),
+      rgba(var(--k-color-white-rgb), 0)
+    ),
+    linear-gradient(180deg, var(--k-color-bg-3), var(--k-color-tertiary));
+  border: 1px solid var(--k-color-border);
+  border-radius: var(--k-radius-sm);
+  color: var(--k-color-text);
+  font-size: var(--k-font-size-body-main);
+  font-family: var(--k-font-sans);
   cursor: pointer;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-  transition: border-color 0.2s, color 0.2s, transform 0.15s, box-shadow 0.2s;
+  box-shadow: inset 0 1px 0 rgba(var(--k-color-white-rgb), 0.04);
+  transition:
+    border-color 0.2s,
+    color 0.2s,
+    transform 0.15s,
+    box-shadow 0.2s;
 }
 .login-btn-oauth:hover {
-  border-color: rgba(202, 168, 96, 0.55);
-  color: var(--Text);
-  transform: translateY(-1px);
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  border-color: rgba(var(--k-color-primary-rgb), 0.55);
+  color: var(--k-color-text);
+  filter: brightness(var(--k-state-hover-brightness));
+  box-shadow: var(--k-shadow-card);
+}
+.login-btn-oauth:active {
+  transform: scale(var(--k-state-active-scale));
+}
+.login-btn-oauth:focus-visible {
+  outline: var(--k-focus-ring);
+  outline-offset: var(--k-focus-ring-offset);
 }
 
 .login-oauth-logo {
@@ -260,47 +374,92 @@
 .login-switch {
   width: 100%;
   text-align: center;
-  font-size: 0.83rem;
-  color: var(--TextDim);
-  margin-top: 0.25rem;
+  font-size: var(--k-font-size-body-main);
+  color: var(--k-text-dim);
+  margin-top: var(--k-space-1);
   margin-bottom: 0;
 }
-.login-switch-link { color: var(--Primary); text-decoration: none; margin-left: 0.2rem; }
-.login-switch-link:hover { text-decoration: underline; }
+.login-switch-link {
+  color: var(--k-color-primary);
+  text-decoration: none;
+  margin-left: var(--k-space-1);
+}
+.login-switch-link:hover {
+  text-decoration: underline;
+}
+.login-switch-link:focus-visible {
+  outline: var(--k-focus-ring);
+  outline-offset: var(--k-focus-ring-offset);
+  border-radius: var(--k-radius-sm);
+}
 
 /* ── Banner error ── */
 .login-banner {
-  padding: 0.7rem 0.9rem;
-  border-radius: 6px;
-  font-size: 0.83rem;
-  margin-bottom: 1rem;
+  padding: var(--k-space-3);
+  border-radius: var(--k-radius-md);
+  font-size: var(--k-font-size-body-main);
+  margin-bottom: var(--k-space-4);
 }
-.login-banner--error { background: #e05252; border: 1px solid var(--ErrorText); color: var(--ErrorText); }
+/* Antes el fondo y el texto eran ambos #e05252: el mensaje de error era
+   ilegible. Ahora fondo tinte sobre superficie oscura + texto en
+   --k-state-error-text, que sí contrasta. */
+.login-banner--error {
+  background: rgba(var(--k-color-error-rgb), 0.12);
+  border: 1px solid var(--k-state-error-text);
+  color: var(--k-state-error-text);
+}
 
-/* ── Responsive ── */
+/* ── Responsive ──
+   Solo geometría: no hay valores de marca en los breakpoints. Los tamaños de
+   texto vienen de la escala tipográfica y no se re-declaran por breakpoint. */
 
 /* Laptop pequeño / tablet horizontal */
 @media (max-width: 1200px) {
-  .login-form-panel { padding: 2.5rem 3rem; }
-  .login-card       { max-width: 540px; }
-  .login-logo-panel { margin-right: -140px; }
+  .login-form-panel {
+    padding: var(--k-space-6) var(--k-space-7);
+  }
+  .login-card {
+    max-width: 540px;
+  }
+  .login-logo-panel {
+    margin-right: -140px;
+  }
   .login-logo-img,
-  .login-logo-3d    { width: 380px !important; height: 380px !important; }
+  .login-logo-3d {
+    width: 380px !important;
+    height: 380px !important;
+  }
 }
 
 /* Tablet vertical */
 @media (max-width: 1024px) {
-  .login-form-panel { width: 70%; min-width: 460px; padding: 2.2rem 2.4rem; }
-  .login-logo-panel { width: 30%; min-width: 220px; margin-right: -110px; }
+  .login-form-panel {
+    width: 70%;
+    min-width: 460px;
+    padding: var(--k-space-6) var(--k-space-5);
+  }
+  .login-logo-panel {
+    width: 30%;
+    min-width: 220px;
+    margin-right: -110px;
+  }
   .login-logo-img,
-  .login-logo-3d    { width: 320px !important; height: 320px !important; }
-  .login-title      { font-size: 1.7rem; margin-bottom: 1.2rem; }
+  .login-logo-3d {
+    width: 320px !important;
+    height: 320px !important;
+  }
+  .login-title {
+    margin-bottom: var(--k-space-4);
+  }
 }
 
 /* Stacking: phone landscape / small tablet */
 @media (max-width: 820px) {
-  .login-page       { display: block; min-height: auto; }
-  .login-layout     {
+  .login-page {
+    display: block;
+    min-height: auto;
+  }
+  .login-layout {
     flex-direction: column;
     justify-content: flex-start;
     align-items: center;
@@ -312,83 +471,131 @@
     width: 100%;
     min-width: 0;
     margin: 0;
-    padding: 0.8rem 0 0;
+    padding: var(--k-space-2) 0 0;
     min-height: 220px;
     z-index: 1;
   }
   .login-logo-img,
-  .login-logo-3d    { width: 240px !important; height: 240px !important; }
+  .login-logo-3d {
+    width: 240px !important;
+    height: 240px !important;
+  }
   .login-form-panel {
     width: 100%;
     min-width: 0;
     min-height: auto;
-    padding: 1.2rem 1.6rem 2rem;
-    border-radius: 22px 22px 0 0;
+    padding: var(--k-space-4) var(--k-space-4) var(--k-space-6);
+    border-radius: var(--k-radius-xl) var(--k-radius-xl) 0 0;
     border-left: none;
     border-right: none;
     border-bottom: none;
-    border-top: 1px solid var(--Border);
-    box-shadow: 0 -20px 60px rgba(0, 0, 0, 0.5);
+    border-top: 1px solid var(--k-color-border);
+    box-shadow: 0 -20px 60px rgba(var(--k-color-black-rgb), 0.5);
     margin-top: -40px;
   }
-  .login-field        { margin-bottom: 0.7rem; }
-  .login-divider      { margin: 0.9rem 0; }
-  .login-row-extras   { margin-bottom: 0.9rem; }
-  .login-card       { max-width: 520px; }
-  .login-title      { font-size: 1.6rem; text-align: center; }
+  .login-field {
+    margin-bottom: var(--k-space-3);
+  }
+  .login-divider {
+    margin: var(--k-space-3) 0;
+  }
+  .login-row-extras {
+    margin-bottom: var(--k-space-3);
+  }
+  .login-card {
+    max-width: 520px;
+  }
+  .login-title {
+    text-align: center;
+  }
 }
 
 /* Phone */
 @media (max-width: 520px) {
-  .login-logo-panel { padding-top: 1rem; min-height: 200px; }
+  .login-logo-panel {
+    padding-top: var(--k-space-4);
+    min-height: 200px;
+  }
   .login-logo-img,
-  .login-logo-3d    { width: 220px !important; height: 220px !important; }
-  .login-form-panel { padding: 1.2rem 1.1rem 2rem; }
-  .login-title      { font-size: 1.45rem; margin-bottom: 1rem; }
-  .login-input      { font-size: 0.9rem; padding: 0.78rem 2.4rem 0.78rem 0.85rem; }
-  .login-field-label{ font-size: 0.74rem; }
-  .login-btn-primary{ padding: 0.85rem; font-size: 0.95rem; }
-  .login-oauth-row  { flex-direction: column; gap: 0.55rem; }
-  .login-btn-oauth  { padding: 0.7rem; font-size: 0.85rem; }
+  .login-logo-3d {
+    width: 220px !important;
+    height: 220px !important;
+  }
+  .login-form-panel {
+    padding: var(--k-space-4) var(--k-space-3) var(--k-space-6);
+  }
+  .login-title {
+    margin-bottom: var(--k-space-4);
+  }
+  .login-oauth-row {
+    flex-direction: column;
+    gap: var(--k-space-2);
+  }
   .login-row-extras {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.5rem;
-    margin-bottom: 1rem;
+    gap: var(--k-space-2);
+    margin-bottom: var(--k-space-4);
   }
-  .login-divider    { margin: 1rem 0; }
+  .login-divider {
+    margin: var(--k-space-4) 0;
+  }
 }
 
 /* Phone muy pequeño */
 @media (max-width: 360px) {
-  .login-form-panel { padding: 1rem 0.85rem 1.6rem; }
-  .login-title      { font-size: 1.3rem; }
+  .login-form-panel {
+    padding: var(--k-space-3) var(--k-space-3) var(--k-space-5);
+  }
   .login-logo-img,
-  .login-logo-3d    { width: 180px !important; height: 180px !important; }
+  .login-logo-3d {
+    width: 180px !important;
+    height: 180px !important;
+  }
 }
 
 /* Stacked + short viewport (portrait phone con poca altura) */
 @media (max-width: 820px) and (max-height: 760px) {
-  .login-logo-panel { min-height: 170px; padding-top: 0.5rem; }
+  .login-logo-panel {
+    min-height: 170px;
+    padding-top: var(--k-space-2);
+  }
   .login-logo-img,
-  .login-logo-3d    { width: 180px !important; height: 180px !important; }
-  .login-form-panel { margin-top: -30px; padding: 1rem 1.4rem 1.5rem; }
-  .login-title      { font-size: 1.4rem; margin-bottom: 0.8rem; }
-  .login-field      { margin-bottom: 0.55rem; }
-  .login-divider    { margin: 0.7rem 0; }
+  .login-logo-3d {
+    width: 180px !important;
+    height: 180px !important;
+  }
+  .login-form-panel {
+    margin-top: -30px;
+    padding: var(--k-space-3) var(--k-space-4) var(--k-space-5);
+  }
+  .login-title {
+    margin-bottom: var(--k-space-3);
+  }
+  .login-field {
+    margin-bottom: var(--k-space-2);
+  }
+  .login-divider {
+    margin: var(--k-space-3) 0;
+  }
 }
 
 /* Landscape bajo (móvil rotado) */
 @media (max-height: 520px) and (orientation: landscape) {
-  .login-page       { min-height: auto; }
-  .login-layout     { min-height: auto; padding: 1rem 0; }
-  .login-logo-panel { display: none; }
+  .login-page {
+    min-height: auto;
+  }
+  .login-layout {
+    min-height: auto;
+    padding: var(--k-space-4) 0;
+  }
+  .login-logo-panel {
+    display: none;
+  }
   .login-form-panel {
     width: 100%;
     min-width: 0;
     min-height: auto;
-    padding: 1.4rem 1.6rem;
-    border-radius: 0;
-    border: none;
+    padding: var(--k-space-5) var(--k-space-4);
   }
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,111 @@
+/**
+ * Kontrol — configuración de Tailwind (SCRUM-13 / HU-32)
+ *
+ * Tailwind NO define valores propios: cada escala apunta a los tokens de
+ * `src/styles/theme.css`. Así las clases utilitarias y el CSS plano leen la
+ * misma fuente de verdad y no pueden divergir. Para cambiar un color se edita
+ * el token, nunca este archivo.
+ *
+ * `preflight: false` es deliberado: el reset global de Tailwind alteraría
+ * márgenes y tipografía en las 19 hojas CSS que todavía no se han migrado
+ * (SCRUM-14..17). Reactivarlo solo cuando no quede CSS legacy.
+ *
+ * @type {import('tailwindcss').Config}
+ */
+export default {
+  corePlugins: {
+    preflight: false,
+  },
+  content: ['./index.html', './src/**/*.{vue,js}'],
+  theme: {
+    extend: {
+      // Los nombres evitan duplicar el prefijo de la utilidad: `surface` en vez
+      // de `bg` produce `bg-surface-2` y no `bg-bg-2`. Equivalencia con Figma
+      // a la derecha de cada línea.
+      colors: {
+        primary: {
+          DEFAULT: 'var(--k-color-primary)', //  color/primary
+          2: 'var(--k-color-primary-2)', //      color/primary2
+        },
+        secondary: 'var(--k-color-secondary)', //   color/Secondary
+        tertiary: 'var(--k-color-tertiary)', //     color/Tertiary
+        border: 'var(--k-color-border)', //         color/Border
+        'pill-back': 'var(--k-color-pill-back)', // color/PillBack
+        surface: {
+          DEFAULT: 'var(--k-color-bg)', //  color/Background
+          2: 'var(--k-color-bg-2)', //      color/Background2
+          3: 'var(--k-color-bg-3)', //      color/Background3
+        },
+        foreground: 'var(--k-color-text)', //     color/Text
+        soft: 'var(--k-text-soft)', //            text/TextSoft
+        muted: 'var(--k-text-muted)', //          text/TextMuted
+        dim: 'var(--k-text-dim)', //              text/TextDim
+        faint: 'var(--k-text-faint)', //          text/TextFaint
+        placeholder: 'var(--k-text-placeholder)', // text/TextPlaceholder
+        success: 'var(--k-color-success)', //     color/Success
+        'success-fg': 'var(--k-state-success-text)', // visualStates/SuccessText
+        error: 'var(--k-color-error)', //         color/Error
+        'error-fg': 'var(--k-state-error-text)', //   visualStates/ErrorText
+        warning: 'var(--k-color-warning)', //     color/Warning
+        'input-bg': 'var(--k-form-input-bg)', //       forms/InputBg
+        'input-focus-bg': 'var(--k-form-input-focus-bg)', // forms/InputFocusBg
+        'btn-text': 'var(--k-form-btn-text)', //       forms/BtnText
+      },
+
+      fontFamily: {
+        display: 'var(--k-font-display)',
+        sans: 'var(--k-font-sans)',
+        mono: 'var(--k-font-mono)',
+      },
+
+      fontSize: {
+        display: 'var(--k-font-size-display)',
+        'heading-1': 'var(--k-font-size-heading-1)',
+        'body-large': 'var(--k-font-size-body-large)',
+        'body-main': 'var(--k-font-size-body-main)',
+        caption: 'var(--k-font-size-caption)',
+      },
+
+      // Nomenclatura de Figma: space-1..space-7 (space-7 = 48px).
+      // ⚠️ Sobrescribe la escala por defecto de Tailwind en 5, 6 y 7:
+      // aquí `p-5` = 24px (no 20px), `p-6` = 32px (no 24px), `p-7` = 48px
+      // (no 28px). Manda la rejilla de Figma, no la de Tailwind.
+      spacing: {
+        1: 'var(--k-space-1)',
+        2: 'var(--k-space-2)',
+        3: 'var(--k-space-3)',
+        4: 'var(--k-space-4)',
+        5: 'var(--k-space-5)',
+        6: 'var(--k-space-6)',
+        7: 'var(--k-space-7)',
+      },
+
+      borderRadius: {
+        sm: 'var(--k-radius-sm)',
+        md: 'var(--k-radius-md)',
+        lg: 'var(--k-radius-lg)',
+        xl: 'var(--k-radius-xl)',
+        pill: 'var(--k-radius-pill)',
+      },
+
+      boxShadow: {
+        card: 'var(--k-shadow-card)',
+        glow: 'var(--k-shadow-glow)',
+        modal: 'var(--k-shadow-modal)',
+      },
+
+      opacity: {
+        disabled: 'var(--k-state-disabled-opacity)',
+      },
+
+      scale: {
+        pressed: 'var(--k-state-active-scale)',
+      },
+
+      strokeWidth: {
+        icon: 'var(--k-icon-stroke)',
+      },
+    },
+  },
+  plugins: [],
+}

--- a/frontend/tests/theme.test.js
+++ b/frontend/tests/theme.test.js
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+/**
+ * Contrato de los design tokens (SCRUM-13 / HU-32).
+ *
+ * Se leen los archivos como texto en vez de montarlos en el DOM: happy-dom no
+ * resuelve cadenas de `var()` anidadas, que es justo lo que hay que verificar.
+ * Estas pruebas fallan si alguien borra un token o rompe la capa de
+ * compatibilidad legacy, que es de lo que dependen SCRUM-14..17.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url))
+const themeCss = readFileSync(resolve(here, '../src/styles/theme.css'), 'utf8')
+const globalsCss = readFileSync(resolve(here, '../globals.css'), 'utf8')
+
+/** Nombres de variable declarados (`--x: valor`) en una hoja. */
+function declaredVars(css) {
+  return new Set([...css.matchAll(/^\s*(--[\w-]+)\s*:/gm)].map((m) => m[1]))
+}
+
+/** Pares alias → token referenciado, para declaraciones del tipo `--A: var(--B);` */
+function aliasPairs(css) {
+  return [...css.matchAll(/^\s*(--[\w-]+)\s*:\s*var\((--[\w-]+)\)\s*;/gm)].map((m) => ({
+    alias: m[1],
+    target: m[2],
+  }))
+}
+
+const themeVars = declaredVars(themeCss)
+
+describe('theme.css — catálogo de tokens', () => {
+  // Cada grupo corresponde a una lámina de Figma (docs/design-tokens-figma.md).
+  const expected = {
+    color: [
+      '--k-color-primary',
+      '--k-color-primary-2',
+      '--k-color-secondary',
+      '--k-color-tertiary',
+      '--k-color-border',
+      '--k-color-pill-back',
+      '--k-color-bg',
+      '--k-color-bg-2',
+      '--k-color-bg-3',
+      '--k-color-text',
+      '--k-color-success',
+      '--k-color-error',
+      '--k-color-warning',
+    ],
+    text: [
+      '--k-text-soft',
+      '--k-text-muted',
+      '--k-text-dim',
+      '--k-text-faint',
+      '--k-text-placeholder',
+    ],
+    visualStates: ['--k-state-error-text', '--k-state-success-text'],
+    forms: ['--k-form-input-bg', '--k-form-input-focus-bg', '--k-form-btn-text'],
+    font: [
+      '--k-font-display',
+      '--k-font-sans',
+      '--k-font-mono',
+      '--k-font-size-display',
+      '--k-font-size-heading-1',
+      '--k-font-size-body-large',
+      '--k-font-size-body-main',
+      '--k-font-size-caption',
+    ],
+    spacing: [
+      '--k-space-1',
+      '--k-space-2',
+      '--k-space-3',
+      '--k-space-4',
+      '--k-space-5',
+      '--k-space-6',
+      '--k-space-7',
+    ],
+    radius: [
+      '--k-radius-sm',
+      '--k-radius-md',
+      '--k-radius-lg',
+      '--k-radius-xl',
+      '--k-radius-pill',
+    ],
+    shadow: ['--k-shadow-card', '--k-shadow-glow', '--k-shadow-modal'],
+    interaction: [
+      '--k-state-hover-brightness',
+      '--k-state-active-scale',
+      '--k-state-disabled-opacity',
+      '--k-focus-ring',
+    ],
+  }
+
+  for (const [group, tokens] of Object.entries(expected)) {
+    it(`declara todos los tokens del grupo ${group}/`, () => {
+      const missing = tokens.filter((t) => !themeVars.has(t))
+      expect(missing).toEqual([])
+    })
+  }
+
+  it('respeta la rejilla de 8pt de Figma (space-7 = 48px)', () => {
+    const scale = { 1: '4px', 2: '8px', 3: '12px', 4: '16px', 5: '24px', 6: '32px', 7: '48px' }
+    for (const [step, px] of Object.entries(scale)) {
+      expect(themeCss).toMatch(new RegExp(`--k-space-${step}:\\s*${px};`))
+    }
+  })
+
+  it('usa los valores de radio de la guía, incluido radius-xl', () => {
+    const radii = { sm: '4px', md: '8px', lg: '12px', xl: '24px', pill: '999px' }
+    for (const [name, px] of Object.entries(radii)) {
+      expect(themeCss).toMatch(new RegExp(`--k-radius-${name}:\\s*${px};`))
+    }
+  })
+
+  it('mantiene el dorado de marca y el texto primario de la guía', () => {
+    expect(themeCss).toMatch(/--k-color-primary:\s*#caa860;/)
+    expect(themeCss).toMatch(/--k-color-text:\s*#faf8f5;/)
+  })
+})
+
+describe('theme.css — mecanismo de temas', () => {
+  it('aplica los tokens tanto en :root como en [data-theme="dark"]', () => {
+    expect(themeCss).toMatch(/:root,\s*\[data-theme='dark'\]\s*\{/)
+  })
+
+  it('declara el selector del tema claro', () => {
+    expect(themeCss).toMatch(/\[data-theme='light'\]\s*\{/)
+  })
+
+  it('respeta prefers-color-scheme cuando no hay preferencia explícita', () => {
+    expect(themeCss).toMatch(/@media \(prefers-color-scheme: light\)/)
+    expect(themeCss).toMatch(/:root:not\(\[data-theme\]\)/)
+  })
+})
+
+describe('globals.css — capa de compatibilidad legacy', () => {
+  // Las 21 variables que existían antes de SCRUM-13. Si alguna desaparece,
+  // rompen las pantallas todavía sin migrar.
+  const legacy = [
+    '--Primary',
+    '--Primary2',
+    '--Secondary',
+    '--Tertiary',
+    '--Border',
+    '--PillBack',
+    '--Text',
+    '--Background',
+    '--Background2',
+    '--Background3',
+    '--Success',
+    '--Error',
+    '--Warning',
+    '--TextMuted',
+    '--TextDim',
+    '--TextPlaceholder',
+    '--ErrorText',
+    '--SuccessText',
+    '--InputBg',
+    '--InputFocusBg',
+    '--BtnText',
+  ]
+
+  const pairs = aliasPairs(globalsCss)
+  const aliased = new Map(pairs.map((p) => [p.alias, p.target]))
+
+  it('conserva las 21 variables legacy', () => {
+    const missing = legacy.filter((v) => !aliased.has(v))
+    expect(missing).toEqual([])
+  })
+
+  it('resuelve cada alias legacy a un token existente en theme.css', () => {
+    const broken = pairs.filter((p) => !themeVars.has(p.target))
+    expect(broken).toEqual([])
+  })
+
+  it('no deja alias legacy fuera de la lista congelada', () => {
+    const extra = [...aliased.keys()].filter((v) => !legacy.includes(v))
+    expect(extra).toEqual([])
+  })
+
+  it('no vuelve a declarar valores de marca: los alias solo apuntan a tokens', () => {
+    const rootBlock = globalsCss.match(/:root\s*\{[\s\S]*?\}/)?.[0] ?? ''
+    // Ningún literal de color dentro del bloque de alias.
+    expect(rootBlock).not.toMatch(/#[0-9a-f]{3,8}/i)
+    expect(rootBlock).not.toMatch(/\brgba?\(/i)
+  })
+
+  it('importa theme.css antes que las directivas de Tailwind', () => {
+    const importIdx = globalsCss.indexOf("@import './src/styles/theme.css'")
+    const tailwindIdx = globalsCss.indexOf('@tailwind')
+    expect(importIdx).toBeGreaterThanOrEqual(0)
+    expect(tailwindIdx).toBeGreaterThan(importIdx)
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,9 +71,25 @@
         "@vitejs/plugin-vue": "^5.1.0",
         "@vitest/coverage-v8": "^4.1.10",
         "@vue/test-utils": "^2.4.11",
+        "autoprefixer": "^10.5.4",
         "happy-dom": "^20.10.6",
+        "postcss": "^8.5.26",
+        "tailwindcss": "^3.4.19",
         "vite": "^6.0.0",
         "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -761,11 +777,22 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -781,7 +808,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -886,6 +913,44 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@one-ini/wasm": {
@@ -1785,6 +1850,47 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "license": "MIT"
@@ -1835,6 +1941,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/autoprefixer": {
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+      "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.6",
+        "caniuse-lite": "^1.0.30001806",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1869,6 +2012,19 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bcrypt": {
       "version": "6.0.0",
       "hasInstallScript": true,
@@ -1886,6 +2042,19 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/body-parser": {
@@ -1918,6 +2087,53 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/bson": {
@@ -1978,6 +2194,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001807",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001807.tgz",
+      "integrity": "sha512-daRXJ9EB/rdRgu7kV+TTl1YUKtlsMWblPl2sLnpg9DZae16QCegol6A1SmCE31Lm9mXC1sRWGt/krouH+/dl7Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2016,6 +2263,44 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cliui": {
@@ -2213,6 +2498,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -2278,6 +2576,20 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.4.2",
@@ -2362,6 +2674,13 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.402",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.402.tgz",
+      "integrity": "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2674,6 +2993,36 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -2681,11 +3030,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -2718,6 +3077,19 @@
       },
       "engines": {
         "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/finalhandler": {
@@ -2811,6 +3183,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "license": "MIT",
@@ -2822,7 +3208,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2927,6 +3312,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/google-auth-library": {
@@ -3139,6 +3537,45 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3147,6 +3584,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/isexe": {
@@ -3222,6 +3682,16 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/js-beautify": {
@@ -3348,6 +3818,26 @@
         }
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "license": "MIT"
@@ -3468,11 +3958,48 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime": {
@@ -3673,10 +4200,22 @@
       "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
       "license": "MIT"
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -3762,6 +4301,16 @@
         "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/nopt": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
@@ -3778,11 +4327,31 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -3858,6 +4427,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -3970,13 +4546,23 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pinia": {
@@ -4001,10 +4587,20 @@
         }
       }
     },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4021,13 +4617,147 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
@@ -4116,6 +4846,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "license": "MIT",
@@ -4136,6 +4887,42 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4143,6 +4930,39 @@
       "dev": true,
       "license": "MIT",
       "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
     },
@@ -4189,6 +5009,30 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.1",
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/rxjs": {
@@ -4660,6 +5504,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -4760,6 +5637,80 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/three": {
       "version": "0.183.2",
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
@@ -4787,7 +5738,7 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -4808,6 +5759,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/toidentifier": {
@@ -4839,6 +5803,13 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4868,6 +5839,37 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uploadthing": {
@@ -4907,6 +5909,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",


### PR DESCRIPTION
Implements SCRUM-13 — translates the SCRUM-12 style guide into code as a single source of truth for the frontend theme.

This is the sprint's blocking task: SCRUM-14, 15, 16 and 17 all build on it.

## What's here

| Scope item | Delivered |
|---|---|
| 1. Tokens as CSS variables | `frontend/src/styles/theme.css` — 65 tokens across colour, typography, spacing, radii, shadows, interaction states and accessibility |
| 2. Tailwind consumes the tokens | `tailwind.config.js` + `postcss.config.mjs` |
| 3. Compatibility layer | `globals.css` reduced to 21 legacy aliases |
| 4. Light and dark theme | `[data-theme]` + `prefers-color-scheme` + `useTheme.js` |
| Acceptance criterion | `LoginView.css` migrated as the pilot screen |

## Two things the ticket assumed that the repo did not have

**Tailwind was never installed.** The frontend is Vue 3 + Vite with plain CSS. It's added here as a *consumer* of the tokens rather than a second place where values live, so utilities and hand-written CSS can't drift. `preflight` is off on purpose — the global reset would change margins and typography across the 19 stylesheets not yet migrated. Pinned to v3 because v4 drops both `tailwind.config.js` and `corePlugins.preflight`.

**There is no light palette.** SCRUM-12 only approved the Luxury Dark identity. The switching mechanism is implemented and verifiable, but `[data-theme="light"]` ships empty with a `TODO(SCRUM-12)`: inventing brand colours to fill that gap isn't a call this task should make. Once Design delivers the palette it's a change to `theme.css` alone — no consumer needs touching.

## Decisions worth a reviewer's attention

- **The guide wins over the old CSS values.** `--Text` `#ffffff`→`#faf8f5`, plus `--TextMuted` and `--TextDim`; adds `TextSoft` and `TextFaint`, which the guide defines but the code never had. Near-imperceptible shifts, but they touch ~96 call sites.
- **`body-large` = 16px is an assumption.** Figma defines the level; neither Figma nor `design-system.md` gives it a px value. Flagged in the code.
- **Spacing follows Figma, not Tailwind.** `p-5` is 24px here, not 20px. Called out in the config.
- **Token naming follows the Figma boards**, so `space-7` is 48px (the doc calls it `space-8`) and `radius/xl` exists (the doc omits it). See the divergences documented in #83.

## Bugs found and fixed while migrating the pilot

- **Error banner was unreadable** — background and text were both `#e05252`, red on red.
- **Success banner had no styles at all** — the template has always rendered `login-banner--success` for invitations, but no rule matched it.
- **Primary button used white text on the gold gradient** — the guide specifies `--BtnText` (`#0e0c08`), which is also the legible choice.

Also adds `:focus-visible` rings and 40px minimum target sizes, both required by SCRUM-12 and previously absent everywhere.

## Verification

- **62 tests pass** (6 suites). `tests/theme.test.js` is new: it asserts every token exists and that no legacy alias is dropped or left pointing at a missing token.
- **Build is clean and unchanged in size** (276.28 kB CSS) — `preflight: false` leaks no reset, and no utilities are emitted because nothing uses them yet. Zero bloat.
- **Driven in a real browser via CDP**, measured rather than eyeballed:
  - legacy `--Primary` resolves to `#caa860` at runtime
  - `:focus-visible` from a real Tab press → `2px solid rgb(202,168,96)`, offset `2px`
  - button hover → `brightness(1.15)` + the glow shadow token
  - error banner → background `rgba(224,82,82,.12)` vs text `rgb(224,82,82)`
  - `data-theme="light"` applies and inherits dark, as designed
  - four breakpoints: 1440 / 1024 / 820 / 390
- **No regression on unmigrated screens** — `/register`, the landing, and `/dashboard`, `/inventory`, `/projects` all render with the alias layer intact and zero exceptions. This is what the compatibility layer exists to guarantee.

## Not in scope

Migrating the other 18 stylesheets and the ~2264 hardcoded hex values — that's SCRUM-14..17. Defining the light palette needs a Design addendum to SCRUM-12.

Closes SCRUM-13.
