### PR TITLE
ci(SCRUM-23): enforce coverage thresholds and add build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,12 +251,12 @@ Acordada en la retrospectiva del Sprint 5 (SCRUM-23). La retrospectiva planteaba
 
 ### Umbrales vigentes
 
-Línea base medida el 11/08/2026.
+Línea base medida el 12/08/2026.
 
 | | Statements | Branches | Functions | Lines |
 |---|---|---|---|---|
-| Backend — actual | 29 | 19 | 17 | 29 |
-| Backend — cierre Sprint 6 | 34 | 24 | 22 | 34 |
+| Backend — actual | 33 | 21 | 23 | 33 |
+| Backend — cierre Sprint 6 | 38 | 26 | 28 | 38 |
 | Frontend — actual | 80 | 80 | 75 | 83 |
 | Frontend — cierre Sprint 6 | 85 | 85 | 80 | 88 |
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Monorepo: **Vue 3 + Vite** en el frontend · **Node.js + Express** en el backend · **PostgreSQL** + **MongoDB** como bases de datos.
 
+[![CI](https://github.com/PabloVS044/Kontrol/actions/workflows/ci.yml/badge.svg?event=pull_request)](https://github.com/PabloVS044/Kontrol/actions/workflows/ci.yml)
+
 ![Vue](https://img.shields.io/badge/Vue-3-42b883?logo=vuedotjs&logoColor=white)
 ![Node](https://img.shields.io/badge/Node-20--22-339933?logo=nodedotjs&logoColor=white)
 ![Express](https://img.shields.io/badge/Express-4-000000?logo=express&logoColor=white)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Monorepo: **Vue 3 + Vite** en el frontend · **Node.js + Express** en el backend
 - [Comandos útiles de Docker](#comandos-útiles-de-docker)
 - [Desarrollo sin Docker (opcional)](#desarrollo-sin-docker-opcional)
 - [Estructura del proyecto](#estructura-del-proyecto)
+- [Cobertura de código](#cobertura-de-código)
 - [Solución de problemas](#solución-de-problemas)
 - [Contribuir](#contribuir)
 
@@ -228,6 +229,53 @@ Kontrol/
 ├── dev.sh                 # Atajo para levantar dev en Linux
 └── package.json           # Workspaces del monorepo
 ```
+
+---
+
+## Cobertura de código
+
+La cobertura no es solo informativa: es un **control automático que bloquea el merge**. Vitest sale con código distinto de cero si un umbral no se cumple, y el workflow de CI propaga ese fallo, así que un PR que baje la cobertura queda en rojo.
+
+```bash
+npm run test:coverage -w backend
+npm run test:coverage -w frontend
+```
+
+### Política de trinquete
+
+Acordada en la retrospectiva del Sprint 5 (SCRUM-23). La retrospectiva planteaba un umbral global único del 60 %, pero ocho de los doce módulos de negocio siguen sin cobertura propia y ese valor habría dejado el pipeline en rojo de inmediato. Se adoptó en su lugar un trinquete de tres reglas:
+
+1. **Umbral del 70 % por módulo crítico** — POS, presupuesto, autenticación y reportes.
+2. **Umbral global fijado en la línea base medida**, sin margen. El umbral es exactamente la cobertura actual: puede mantenerse o subir, nunca bajar.
+3. **+5 puntos porcentuales por sprint** sobre el umbral global.
+
+### Umbrales vigentes
+
+Línea base medida el 11/08/2026.
+
+| | Statements | Branches | Functions | Lines |
+|---|---|---|---|---|
+| Backend — actual | 29 | 19 | 17 | 29 |
+| Backend — cierre Sprint 6 | 34 | 24 | 22 | 34 |
+| Frontend — actual | 80 | 80 | 75 | 83 |
+| Frontend — cierre Sprint 6 | 85 | 85 | 80 | 88 |
+
+Por módulo crítico, al 70 % en las cuatro métricas:
+
+| Módulo | Archivos |
+|---|---|
+| POS | `frontend/src/utils/sales.js` |
+| Presupuesto | `backend/src/utils/budgetCalculations.js` |
+| Autenticación | `backend/src/middleware/require{Auth,Role}.js` |
+| Reportes | `backend/src/controllers/reportsController.js`, `backend/src/routes/reportsRoutes.js`, `backend/src/schemas/reportsSchemas.js` |
+
+`frontend/src/stores/auth.js` lleva un escalón temporal más bajo (60/55/55/60) porque hoy mide 66.66/60.41/59.25/69.73; sube a 70 cuando se amplíe `authStore.test.js`.
+
+### Qué se mide
+
+Se mide **solo lo que algún test importa**. `coverage.all` no existe en Vitest 4 y no se declara `coverage.include`, así que un archivo que ningún test toca no aparece en el reporte ni afecta al porcentaje. Es intencional: mantiene el gate estable mientras entra código sin tests propios.
+
+Consecuencia a tener presente: un glob de umbral que no case con ningún archivo del reporte **pasa en vacío, sin avisar**. Si se borra el test que cubre uno de los archivos de la tabla, su umbral deja de proteger nada.
 
 ---
 

--- a/backend/tests/reports.controller.test.js
+++ b/backend/tests/reports.controller.test.js
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Mockeamos el pool para no tocar Postgres: controlamos cada consulta.
+vi.mock('../src/db/pool.js', () => ({
+  default: { query: vi.fn() },
+}))
+
+import request from 'supertest'
+import pool from '../src/db/pool.js'
+import { buildTestApp, signToken, companyMembership, dbRows } from './helpers/authTestApp.js'
+
+const app = buildTestApp()
+
+// Cabeceras comunes: usuario autenticado sobre la empresa 1.
+const auth = (req) => req.set('Authorization', `Bearer ${signToken()}`).set('X-Company-ID', '1')
+
+const reportRow = {
+  id_reporte: 1,
+  titulo: 'Reporte de avance',
+  tipo: 'AVANCE',
+  contenido_url: null,
+  id_proyecto: 10,
+  id_usuario: 7,
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  // Los handlers loguean el error antes de responder 500; silenciamos el ruido.
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+/**
+ * Lógica del controller de reportes (SCRUM-23).
+ *
+ * El módulo de reportes es uno de los cuatro críticos del trinquete de
+ * cobertura, así que cada handler se prueba en sus tres caminos: éxito,
+ * recurso inexistente y fallo de base de datos.
+ *
+ * La primera consulta de cada petición siempre la consume `requireCompany`
+ * (verificación de pertenencia a la empresa); las siguientes son del handler.
+ */
+describe('Reportes · controller', () => {
+  describe('GET /api/reports', () => {
+    it('devuelve 200 con los reportes de la empresa', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValueOnce(dbRows([reportRow]))
+
+      const res = await auth(request(app).get('/api/reports'))
+
+      expect(res.status).toBe(200)
+      expect(res.body.success).toBe(true)
+      expect(res.body.data).toEqual([reportRow])
+    })
+
+    it('devuelve lista vacía cuando la empresa no tiene reportes', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValueOnce(dbRows([]))
+
+      const res = await auth(request(app).get('/api/reports'))
+
+      expect(res.status).toBe(200)
+      expect(res.body.data).toEqual([])
+    })
+
+    it('devuelve 500 si la consulta falla', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockRejectedValueOnce(new Error('db caída'))
+
+      const res = await auth(request(app).get('/api/reports'))
+
+      expect(res.status).toBe(500)
+      expect(res.body.success).toBe(false)
+    })
+  })
+
+  describe('GET /api/reports/:id', () => {
+    it('devuelve 200 con el reporte pedido', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValueOnce(dbRows([reportRow]))
+
+      const res = await auth(request(app).get('/api/reports/1'))
+
+      expect(res.status).toBe(200)
+      expect(res.body.data).toEqual(reportRow)
+    })
+
+    it('devuelve 404 si el reporte no existe en esa empresa', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValueOnce(dbRows([]))
+
+      const res = await auth(request(app).get('/api/reports/999'))
+
+      expect(res.status).toBe(404)
+      expect(res.body.message).toBe('Report not found.')
+    })
+
+    it('devuelve 500 si la consulta falla', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockRejectedValueOnce(new Error('db caída'))
+
+      const res = await auth(request(app).get('/api/reports/1'))
+
+      expect(res.status).toBe(500)
+    })
+  })
+
+  describe('POST /api/reports', () => {
+    const nuevoReporte = { titulo: 'Reporte de avance', tipo: 'AVANCE', id_proyecto: 10 }
+
+    it('devuelve 201 y el reporte creado', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin')) // pertenencia
+        .mockResolvedValueOnce(dbRows([{ id_proyecto: 10 }])) // proyecto existe
+        .mockResolvedValueOnce(dbRows([reportRow])) // insert
+
+      const res = await auth(request(app).post('/api/reports')).send(nuevoReporte)
+
+      expect(res.status).toBe(201)
+      expect(res.body.data).toEqual(reportRow)
+    })
+
+    it('devuelve 404 si el proyecto no pertenece a la empresa', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValueOnce(dbRows([])) // proyecto inexistente
+
+      const res = await auth(request(app).post('/api/reports')).send(nuevoReporte)
+
+      expect(res.status).toBe(404)
+      expect(res.body.message).toBe('Project not found.')
+    })
+
+    it('devuelve 500 si el insert falla', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValueOnce(dbRows([{ id_proyecto: 10 }]))
+        .mockRejectedValueOnce(new Error('db caída'))
+
+      const res = await auth(request(app).post('/api/reports')).send(nuevoReporte)
+
+      expect(res.status).toBe(500)
+    })
+  })
+
+  describe('PUT /api/reports/:id', () => {
+    it('devuelve 200 con el reporte actualizado', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValueOnce(dbRows([{ ...reportRow, titulo: 'Título nuevo' }]))
+
+      const res = await auth(request(app).put('/api/reports/1')).send({ titulo: 'Título nuevo' })
+
+      expect(res.status).toBe(200)
+      expect(res.body.data.titulo).toBe('Título nuevo')
+    })
+
+    it('devuelve 404 si el reporte no existe en esa empresa', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValueOnce(dbRows([]))
+
+      const res = await auth(request(app).put('/api/reports/999')).send({ titulo: 'Título nuevo' })
+
+      expect(res.status).toBe(404)
+    })
+
+    // Cubre el `.refine()` de updateReportSchema: sin campos no hay nada que actualizar.
+    it('devuelve 400 si no se envía ningún campo', async () => {
+      pool.query.mockResolvedValueOnce(companyMembership('admin'))
+
+      const res = await auth(request(app).put('/api/reports/1')).send({})
+
+      expect(res.status).toBe(400)
+    })
+
+    it('devuelve 500 si el update falla', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockRejectedValueOnce(new Error('db caída'))
+
+      const res = await auth(request(app).put('/api/reports/1')).send({ titulo: 'Título nuevo' })
+
+      expect(res.status).toBe(500)
+    })
+  })
+
+  describe('DELETE /api/reports/:id', () => {
+    it('devuelve 200 al borrar el reporte', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValueOnce(dbRows([{ id_reporte: 1 }]))
+
+      const res = await auth(request(app).delete('/api/reports/1'))
+
+      expect(res.status).toBe(200)
+      expect(res.body.message).toBe('Report deleted.')
+    })
+
+    it('devuelve 404 si el reporte no existe en esa empresa', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValueOnce(dbRows([]))
+
+      const res = await auth(request(app).delete('/api/reports/999'))
+
+      expect(res.status).toBe(404)
+    })
+
+    it('devuelve 500 si el delete falla', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockRejectedValueOnce(new Error('db caída'))
+
+      const res = await auth(request(app).delete('/api/reports/1'))
+
+      expect(res.status).toBe(500)
+    })
+  })
+
+  describe('GET /api/reports/summary', () => {
+    // Fila tal como la devuelve la consulta agregada del resumen.
+    const proyecto = (over = {}) => ({
+      id_proyecto: 10,
+      nombre: 'Proyecto A',
+      descripcion: null,
+      estado: 'EN_PROGRESO',
+      presupuesto_total: '1000',
+      total_tareas: 4,
+      tareas_completadas: 2,
+      tareas_en_progreso: 1,
+      tareas_pendientes: 1,
+      presupuesto_planificado: '800',
+      presupuesto_real: '600',
+      progreso_actual: 0,
+      ...over,
+    })
+
+    it('usa el progreso registrado cuando existe una entrada de avance', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValueOnce(dbRows([proyecto({ progreso_actual: 75 })]))
+
+      const res = await auth(request(app).get('/api/reports/summary'))
+
+      expect(res.status).toBe(200)
+      expect(res.body.data.proyectos[0].progreso_actual).toBe(75)
+    })
+
+    // Sin entrada de avance, el progreso se deriva de las tareas completadas.
+    it('deriva el progreso de las tareas cuando no hay entrada de avance', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValueOnce(dbRows([proyecto()])) // 2 de 4 tareas → 50 %
+
+      const res = await auth(request(app).get('/api/reports/summary'))
+
+      expect(res.body.data.proyectos[0].progreso_actual).toBe(50)
+    })
+
+    it('devuelve progreso 0 cuando el proyecto no tiene tareas ni avance', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockResolvedValueOnce(dbRows([proyecto({ total_tareas: 0, tareas_completadas: 0 })]))
+
+      const res = await auth(request(app).get('/api/reports/summary'))
+
+      expect(res.body.data.proyectos[0].progreso_actual).toBe(0)
+    })
+
+    it('agrega los totales de la empresa', async () => {
+      pool.query.mockResolvedValueOnce(companyMembership('admin')).mockResolvedValueOnce(
+        dbRows([
+          proyecto({ id_proyecto: 10, estado: 'EN_PROGRESO', presupuesto_total: '1000' }),
+          proyecto({ id_proyecto: 11, estado: 'COMPLETADO', presupuesto_total: '2500' }),
+          proyecto({ id_proyecto: 12, estado: 'PLANIFICADO', presupuesto_total: null }),
+        ])
+      )
+
+      const res = await auth(request(app).get('/api/reports/summary'))
+
+      expect(res.body.data.totales).toEqual({
+        total_proyectos: 3,
+        proyectos_activos: 1,
+        proyectos_completados: 1,
+        // El proyecto sin presupuesto cuenta como 0, no como NaN.
+        presupuesto_total: 3500,
+      })
+    })
+
+    it('devuelve 500 si la consulta falla', async () => {
+      pool.query
+        .mockResolvedValueOnce(companyMembership('admin'))
+        .mockRejectedValueOnce(new Error('db caída'))
+
+      const res = await auth(request(app).get('/api/reports/summary'))
+
+      expect(res.status).toBe(500)
+    })
+  })
+})

--- a/backend/vitest.config.js
+++ b/backend/vitest.config.js
@@ -36,7 +36,57 @@ export default defineConfig({
         statements: 25, // base 29.08 % · margen 4.08
         branches: 15, //   base 19.16 % · margen 4.16
         functions: 14, //  base 17.88 % · margen 3.88
-        lines: 25 //       base 29.13 % · margen 4.13
+        lines: 25, //      base 29.13 % · margen 4.13
+
+        // Umbrales por módulo crítico. Los globs se resuelven con picomatch
+        // contra la ruta relativa a la raíz del workspace, y los archivos que
+        // casan siguen contando también en el umbral global de arriba.
+        //
+        // Ojo: un glob que no casa con ningún archivo del reporte pasa en
+        // vacío, sin avisar. Si se borra el test que cubre uno de estos
+        // archivos, su umbral deja de proteger nada.
+
+        // Presupuesto: cálculo financiero puro. Medido 100 % en las cuatro.
+        'src/utils/budgetCalculations.js': {
+          statements: 70,
+          branches: 70,
+          functions: 70,
+          lines: 70
+        },
+
+        // Autenticación: verificación de token y de rol. Medido 100 % en las
+        // cuatro para ambos archivos. La expansión de llaves casa solo con
+        // requireAuth.js y requireRole.js — requireCompanyRole.js queda fuera.
+        'src/middleware/require{Auth,Role}.js': {
+          statements: 70,
+          branches: 70,
+          functions: 70,
+          lines: 70
+        }
+
+        // Reportes: umbral desactivado a propósito. Los tests del módulo
+        // llegan el 17/08/2026. Cobertura medida el 11/08/2026:
+        // reportsController.js 29.85 / 14.28 / 20 / 29.85.
+        // Descomentar y calibrar cuando esos tests estén en develop.
+        //
+        // 'src/controllers/reportsController.js': {
+        //   statements: 70,
+        //   branches: 70,
+        //   functions: 70,
+        //   lines: 70
+        // },
+        // 'src/routes/reportsRoutes.js': {
+        //   statements: 70,
+        //   branches: 70,
+        //   functions: 70,
+        //   lines: 70
+        // },
+        // 'src/schemas/reportsSchemas.js': {
+        //   statements: 70,
+        //   branches: 70,
+        //   functions: 70,
+        //   lines: 70
+        // }
       }
     }
   }

--- a/backend/vitest.config.js
+++ b/backend/vitest.config.js
@@ -28,15 +28,14 @@ export default defineConfig({
       // Vitest sale con código 1 si no se cumple un umbral, así que el step
       // `npm run test:coverage -w backend` de ci.yml pone el job en rojo solo.
       thresholds: {
-        // Línea base medida el 11/08/2026 sobre 29 archivos (1107 sentencias),
-        // menos ~4 puntos de margen. El margen no cubre el código nuevo sin
-        // tests (ese ni entra al denominador), sino el movimiento normal del
-        // denominador: un controller de ~200 sentencias que entre al 10% mueve
-        // el total ~1.5 puntos.
-        statements: 25, // base 29.08 % · margen 4.08
-        branches: 15, //   base 19.16 % · margen 4.16
-        functions: 14, //  base 17.88 % · margen 3.88
-        lines: 25, //      base 29.13 % · margen 4.13
+        // Trinquete, punto 2: el umbral global se fija en la línea base medida
+        // el 11/08/2026 sobre 29 archivos (1107 sentencias), truncada a
+        // entero. Sin margen — el umbral es exactamente lo que hay hoy, así
+        // que la cobertura solo puede mantenerse o subir, nunca bajar.
+        statements: 29, // base 29.08 %
+        branches: 19, //   base 19.16 %
+        functions: 17, //  base 17.88 %
+        lines: 29, //      base 29.13 %
 
         // Umbrales por módulo crítico. Los globs se resuelven con picomatch
         // contra la ruta relativa a la raíz del workspace, y los archivos que

--- a/backend/vitest.config.js
+++ b/backend/vitest.config.js
@@ -65,31 +65,36 @@ export default defineConfig({
           branches: 70,
           functions: 70,
           lines: 70
-        }
+        },
 
-        // Reportes: umbral desactivado a propósito. Los tests del módulo
-        // llegan el 17/08/2026. Cobertura medida el 11/08/2026:
-        // reportsController.js 29.85 / 14.28 / 20 / 29.85.
-        // Descomentar y calibrar cuando esos tests estén en develop.
+        // Reportes: cuarto módulo crítico del trinquete de SCRUM-23.
         //
-        // 'src/controllers/reportsController.js': {
-        //   statements: 70,
-        //   branches: 70,
-        //   functions: 70,
-        //   lines: 70
-        // },
-        // 'src/routes/reportsRoutes.js': {
-        //   statements: 70,
-        //   branches: 70,
-        //   functions: 70,
-        //   lines: 70
-        // },
-        // 'src/schemas/reportsSchemas.js': {
-        //   statements: 70,
-        //   branches: 70,
-        //   functions: 70,
-        //   lines: 70
-        // }
+        // AVISO — este umbral NO se cumple hoy y deja el job del backend en
+        // rojo. Medido el 11/08/2026:
+        //   reportsController.js  29.85 / 14.28 / 20 / 29.85
+        //   reportsRoutes.js      100 en las cuatro
+        //   reportsSchemas.js     80 / 100 / 0 / 80
+        // Los tests del módulo llegan el 17/08/2026; hasta entonces el gate
+        // bloquea el merge. Se activa por decisión explícita de la tarea, que
+        // lista reportes junto a POS, presupuesto y autenticación.
+        'src/controllers/reportsController.js': {
+          statements: 70,
+          branches: 70,
+          functions: 70,
+          lines: 70
+        },
+        'src/routes/reportsRoutes.js': {
+          statements: 70,
+          branches: 70,
+          functions: 70,
+          lines: 70
+        },
+        'src/schemas/reportsSchemas.js': {
+          statements: 70,
+          branches: 70,
+          functions: 70,
+          lines: 70
+        }
       }
     }
   }

--- a/backend/vitest.config.js
+++ b/backend/vitest.config.js
@@ -4,6 +4,26 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: ['tests/**/*.test.js']
+    include: ['tests/**/*.test.js'],
+
+    coverage: {
+      provider: 'v8',
+
+      // Los reporters por defecto más `json-summary`, que escribe
+      // `coverage/coverage-summary.json`: de ahí salen los porcentajes exactos
+      // para el informe del sprint sin tener que abrir el reporte HTML.
+      reporter: ['text', 'html', 'clover', 'json', 'json-summary'],
+
+      // En Vitest 4 `coverageConfigDefaults.exclude` viene vacío, así que sin
+      // esta línea `tests/helpers/authTestApp.js` cuenta como código medido y
+      // infla la cobertura del backend.
+      exclude: ['tests/**']
+
+      // Nota sobre el denominador: `coverage.all` ya no existe en Vitest 4. Sin
+      // declarar `coverage.include`, solo se mide lo que algún test importa; un
+      // archivo que nadie prueba no aparece en el reporte y no baja el
+      // porcentaje. Es intencional: mantiene el gate estable mientras entra
+      // código sin tests propios.
+    }
   }
 })

--- a/backend/vitest.config.js
+++ b/backend/vitest.config.js
@@ -29,16 +29,19 @@ export default defineConfig({
       // `npm run test:coverage -w backend` de ci.yml pone el job en rojo solo.
       thresholds: {
         // Trinquete, punto 2: el umbral global se fija en la línea base medida
-        // el 11/08/2026 sobre 29 archivos (1107 sentencias), truncada a
-        // entero. Sin margen — el umbral es exactamente lo que hay hoy, así
-        // que la cobertura solo puede mantenerse o subir, nunca bajar.
-        statements: 29, // base 29.08 %
-        branches: 19, //   base 19.16 %
-        functions: 17, //  base 17.88 %
-        lines: 29, //      base 29.13 %
+        // el 12/08/2026, truncada a entero. Sin margen — el umbral es
+        // exactamente lo que hay hoy, así que la cobertura solo puede
+        // mantenerse o subir, nunca bajar.
+        //
+        // La base subió de 29.08/19.16/17.88/29.13 a la actual al cubrir el
+        // módulo de reportes; el umbral sube con ella para fijar la mejora.
+        statements: 33, // base 33.42 %
+        branches: 21, //   base 21.33 %
+        functions: 23, //  base 23.84 %
+        lines: 33, //      base 33.71 %
 
         // Trinquete, punto 3: +5 puntos porcentuales por sprint sobre el
-        // umbral global. Próxima subida, al cierre del Sprint 6: 34/24/22/34.
+        // umbral global. Próxima subida, al cierre del Sprint 6: 38/26/28/38.
         // La política completa está en el README, sección «Cobertura».
 
         // Umbrales por módulo crítico. Los globs se resuelven con picomatch
@@ -68,15 +71,8 @@ export default defineConfig({
         },
 
         // Reportes: cuarto módulo crítico del trinquete de SCRUM-23.
-        //
-        // AVISO — este umbral NO se cumple hoy y deja el job del backend en
-        // rojo. Medido el 11/08/2026:
-        //   reportsController.js  29.85 / 14.28 / 20 / 29.85
-        //   reportsRoutes.js      100 en las cuatro
-        //   reportsSchemas.js     80 / 100 / 0 / 80
-        // Los tests del módulo llegan el 17/08/2026; hasta entonces el gate
-        // bloquea el merge. Se activa por decisión explícita de la tarea, que
-        // lista reportes junto a POS, presupuesto y autenticación.
+        // Cubierto por `tests/reports.controller.test.js`. Medido el
+        // 12/08/2026: los tres archivos al 100 % en las cuatro métricas.
         'src/controllers/reportsController.js': {
           statements: 70,
           branches: 70,

--- a/backend/vitest.config.js
+++ b/backend/vitest.config.js
@@ -17,13 +17,27 @@ export default defineConfig({
       // En Vitest 4 `coverageConfigDefaults.exclude` viene vacío, así que sin
       // esta línea `tests/helpers/authTestApp.js` cuenta como código medido y
       // infla la cobertura del backend.
-      exclude: ['tests/**']
+      exclude: ['tests/**'],
 
       // Nota sobre el denominador: `coverage.all` ya no existe en Vitest 4. Sin
       // declarar `coverage.include`, solo se mide lo que algún test importa; un
       // archivo que nadie prueba no aparece en el reporte y no baja el
       // porcentaje. Es intencional: mantiene el gate estable mientras entra
       // código sin tests propios.
+
+      // Vitest sale con código 1 si no se cumple un umbral, así que el step
+      // `npm run test:coverage -w backend` de ci.yml pone el job en rojo solo.
+      thresholds: {
+        // Línea base medida el 11/08/2026 sobre 29 archivos (1107 sentencias),
+        // menos ~4 puntos de margen. El margen no cubre el código nuevo sin
+        // tests (ese ni entra al denominador), sino el movimiento normal del
+        // denominador: un controller de ~200 sentencias que entre al 10% mueve
+        // el total ~1.5 puntos.
+        statements: 25, // base 29.08 % · margen 4.08
+        branches: 15, //   base 19.16 % · margen 4.16
+        functions: 14, //  base 17.88 % · margen 3.88
+        lines: 25 //       base 29.13 % · margen 4.13
+      }
     }
   }
 })

--- a/backend/vitest.config.js
+++ b/backend/vitest.config.js
@@ -37,6 +37,10 @@ export default defineConfig({
         functions: 17, //  base 17.88 %
         lines: 29, //      base 29.13 %
 
+        // Trinquete, punto 3: +5 puntos porcentuales por sprint sobre el
+        // umbral global. Próxima subida, al cierre del Sprint 6: 34/24/22/34.
+        // La política completa está en el README, sección «Cobertura».
+
         // Umbrales por módulo crítico. Los globs se resuelven con picomatch
         // contra la ruta relativa a la raíz del workspace, y los archivos que
         // casan siguen contando también en el umbral global de arriba.

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -19,13 +19,34 @@ export default mergeConfig(
 
         // En Vitest 4 `coverageConfigDefaults.exclude` viene vacío; se declara
         // explícitamente para que nada de `tests/` cuente como código medido.
-        exclude: ['tests/**']
+        exclude: ['tests/**'],
 
         // Nota sobre el denominador: `coverage.all` ya no existe en Vitest 4.
         // Sin declarar `coverage.include`, solo se mide lo que algún test
         // importa; un archivo que nadie prueba no aparece en el reporte y no
         // baja el porcentaje. Es intencional: mantiene el gate estable
         // mientras entra código sin tests propios.
+
+        // Vitest sale con código 1 si no se cumple un umbral, así que el step
+        // `npm run test:coverage -w frontend` de ci.yml pone el job en rojo
+        // por sí solo.
+        thresholds: {
+          // Línea base medida el 11/08/2026 sobre 6 archivos (168 sentencias),
+          // menos ~10 puntos de margen. El margen es mayor que el del backend
+          // a propósito: con un denominador tan pequeño, un solo archivo lo
+          // mueve muchísimo. Medido: si el rediseño deja `Button.vue` (5
+          // sentencias, 3 funciones, hoy al 100 %) sin cubrir, functions cae
+          // de 75.51 % a 69.39 %.
+          statements: 70, // base 80.95 % · margen 10.95
+          branches: 70, //   base 80.46 % · margen 10.46
+          functions: 65, //  base 75.51 % · margen 10.51
+          lines: 72 //       base 83.10 % · margen 11.10
+
+          // Pendiente: recalibrar el 17/08/2026. Cuando lleguen los tests
+          // nuevos, cualquiera que importe una vista completa mete esa vista
+          // entera en el denominador de golpe y ningún margen razonable
+          // aguanta ese salto.
+        }
       }
     }
   })

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -40,12 +40,65 @@ export default mergeConfig(
           statements: 70, // base 80.95 % · margen 10.95
           branches: 70, //   base 80.46 % · margen 10.46
           functions: 65, //  base 75.51 % · margen 10.51
-          lines: 72 //       base 83.10 % · margen 11.10
+          lines: 72, //      base 83.10 % · margen 11.10
 
           // Pendiente: recalibrar el 17/08/2026. Cuando lleguen los tests
           // nuevos, cualquiera que importe una vista completa mete esa vista
           // entera en el denominador de golpe y ningún margen razonable
           // aguanta ese salto.
+
+          // Umbrales por módulo crítico. Los globs se resuelven con picomatch
+          // contra la ruta relativa a la raíz del workspace, y los archivos
+          // que casan siguen contando también en el umbral global de arriba.
+          //
+          // Ojo: un glob que no casa con ningún archivo del reporte pasa en
+          // vacío, sin avisar. Si se borra el test que cubre uno de estos
+          // archivos, su umbral deja de proteger nada.
+
+          // POS: subtotal, descuento e IVA de una venta. Es el cálculo con
+          // mayor riesgo financiero del sistema. Medido 95.45/94.44/100/100.
+          'src/utils/sales.js': {
+            statements: 70,
+            branches: 70,
+            functions: 70,
+            lines: 70
+          },
+
+          // Autenticación de frontend. Escalón temporal por debajo del 70 %:
+          // medido 66.66/60.41/59.25/69.73, es decir por debajo en las cuatro
+          // métricas pese a tener `authStore.test.js` propio. Se fija encima
+          // de lo medido para frenar regresiones; subir a 70 cuando se amplíe
+          // ese test.
+          'src/stores/auth.js': {
+            statements: 60,
+            branches: 55,
+            functions: 55,
+            lines: 60
+          }
+
+          // Reportes: umbral desactivado a propósito. Los tests del módulo
+          // llegan el 17/08/2026. Hoy (11/08/2026) ninguno de estos archivos
+          // entra siquiera al reporte, porque ningún test los importa.
+          // Descomentar y calibrar cuando esos tests estén en develop.
+          //
+          // 'src/views/ReportsView.vue': {
+          //   statements: 70,
+          //   branches: 70,
+          //   functions: 70,
+          //   lines: 70
+          // },
+          // 'src/views/ReportDetailView.vue': {
+          //   statements: 70,
+          //   branches: 70,
+          //   functions: 70,
+          //   lines: 70
+          // },
+          // 'src/components/reports/**': {
+          //   statements: 70,
+          //   branches: 70,
+          //   functions: 70,
+          //   lines: 70
+          // }
         }
       }
     }

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -32,7 +32,7 @@ export default mergeConfig(
         // por sí solo.
         thresholds: {
           // Trinquete, punto 2: el umbral global se fija en la línea base
-          // medida el 11/08/2026 sobre 6 archivos (168 sentencias), truncada a
+          // medida el 12/08/2026 sobre 6 archivos (168 sentencias), truncada a
           // entero. Sin margen — el umbral es exactamente lo que hay hoy.
           statements: 80, // base 80.95 %
           branches: 80, //   base 80.46 %
@@ -83,7 +83,7 @@ export default mergeConfig(
 
           // Reportes: cuarto módulo crítico del trinquete de SCRUM-23.
           //
-          // Hoy (11/08/2026) ninguno de estos archivos entra al reporte de
+          // Hoy (12/08/2026) ninguno de estos archivos entra al reporte de
           // cobertura, porque ningún test los importa. Un glob sin archivos
           // que casen pasa en vacío, así que estos tres umbrales no fallan
           // pero tampoco protegen nada todavía: empiezan a tener efecto real

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -31,21 +31,21 @@ export default mergeConfig(
         // `npm run test:coverage -w frontend` de ci.yml pone el job en rojo
         // por sí solo.
         thresholds: {
-          // Línea base medida el 11/08/2026 sobre 6 archivos (168 sentencias),
-          // menos ~10 puntos de margen. El margen es mayor que el del backend
-          // a propósito: con un denominador tan pequeño, un solo archivo lo
-          // mueve muchísimo. Medido: si el rediseño deja `Button.vue` (5
-          // sentencias, 3 funciones, hoy al 100 %) sin cubrir, functions cae
-          // de 75.51 % a 69.39 %.
-          statements: 70, // base 80.95 % · margen 10.95
-          branches: 70, //   base 80.46 % · margen 10.46
-          functions: 65, //  base 75.51 % · margen 10.51
-          lines: 72, //      base 83.10 % · margen 11.10
+          // Trinquete, punto 2: el umbral global se fija en la línea base
+          // medida el 11/08/2026 sobre 6 archivos (168 sentencias), truncada a
+          // entero. Sin margen — el umbral es exactamente lo que hay hoy.
+          statements: 80, // base 80.95 %
+          branches: 80, //   base 80.46 %
+          functions: 75, //  base 75.51 %
+          lines: 83, //      base 83.10 %
 
-          // Pendiente: recalibrar el 17/08/2026. Cuando lleguen los tests
-          // nuevos, cualquiera que importe una vista completa mete esa vista
-          // entera en el denominador de golpe y ningún margen razonable
-          // aguanta ese salto.
+          // Aviso: el denominador del frontend es de solo 168 sentencias en 6
+          // archivos, así que un único archivo lo mueve muchísimo. Medido: si
+          // el rediseño deja `Button.vue` (5 sentencias, 3 funciones, hoy al
+          // 100 %) sin cubrir, functions cae de 75.51 % a 69.39 % y este
+          // umbral se incumple. Al ir sin margen por decisión de SCRUM-23,
+          // cualquier PR que toque un archivo cubierto puede requerir subir
+          // cobertura en el mismo PR.
 
           // Umbrales por módulo crítico. Los globs se resuelven con picomatch
           // contra la ruta relativa a la raíz del workspace, y los archivos

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -39,6 +39,11 @@ export default mergeConfig(
           functions: 75, //  base 75.51 %
           lines: 83, //      base 83.10 %
 
+          // Trinquete, punto 3: +5 puntos porcentuales por sprint sobre el
+          // umbral global. Próxima subida, al cierre del Sprint 6:
+          // 85/85/80/88. La política completa está en el README, sección
+          // «Cobertura».
+
           // Aviso: el denominador del frontend es de solo 168 sentencias en 6
           // archivos, así que un único archivo lo mueve muchísimo. Medido: si
           // el rediseño deja `Button.vue` (5 sentencias, 3 funciones, hoy al

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -79,31 +79,33 @@ export default mergeConfig(
             branches: 55,
             functions: 55,
             lines: 60
-          }
+          },
 
-          // Reportes: umbral desactivado a propósito. Los tests del módulo
-          // llegan el 17/08/2026. Hoy (11/08/2026) ninguno de estos archivos
-          // entra siquiera al reporte, porque ningún test los importa.
-          // Descomentar y calibrar cuando esos tests estén en develop.
+          // Reportes: cuarto módulo crítico del trinquete de SCRUM-23.
           //
-          // 'src/views/ReportsView.vue': {
-          //   statements: 70,
-          //   branches: 70,
-          //   functions: 70,
-          //   lines: 70
-          // },
-          // 'src/views/ReportDetailView.vue': {
-          //   statements: 70,
-          //   branches: 70,
-          //   functions: 70,
-          //   lines: 70
-          // },
-          // 'src/components/reports/**': {
-          //   statements: 70,
-          //   branches: 70,
-          //   functions: 70,
-          //   lines: 70
-          // }
+          // Hoy (11/08/2026) ninguno de estos archivos entra al reporte de
+          // cobertura, porque ningún test los importa. Un glob sin archivos
+          // que casen pasa en vacío, así que estos tres umbrales no fallan
+          // pero tampoco protegen nada todavía: empiezan a tener efecto real
+          // cuando lleguen los tests del módulo el 17/08/2026.
+          'src/views/ReportsView.vue': {
+            statements: 70,
+            branches: 70,
+            functions: 70,
+            lines: 70
+          },
+          'src/views/ReportDetailView.vue': {
+            statements: 70,
+            branches: 70,
+            functions: 70,
+            lines: 70
+          },
+          'src/components/reports/**': {
+            statements: 70,
+            branches: 70,
+            functions: 70,
+            lines: 70
+          }
         }
       }
     }

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -7,7 +7,26 @@ export default mergeConfig(
     test: {
       environment: 'happy-dom',
       globals: true,
-      include: ['tests/**/*.test.js']
+      include: ['tests/**/*.test.js'],
+
+      coverage: {
+        provider: 'v8',
+
+        // Los reporters por defecto más `json-summary`, que escribe
+        // `coverage/coverage-summary.json`: de ahí salen los porcentajes
+        // exactos para el informe del sprint sin abrir el reporte HTML.
+        reporter: ['text', 'html', 'clover', 'json', 'json-summary'],
+
+        // En Vitest 4 `coverageConfigDefaults.exclude` viene vacío; se declara
+        // explícitamente para que nada de `tests/` cuente como código medido.
+        exclude: ['tests/**']
+
+        // Nota sobre el denominador: `coverage.all` ya no existe en Vitest 4.
+        // Sin declarar `coverage.include`, solo se mide lo que algún test
+        // importa; un archivo que nadie prueba no aparece en el reporte y no
+        // baja el porcentaje. Es intencional: mantiene el gate estable
+        // mientras entra código sin tests propios.
+      }
     }
   })
 )


### PR DESCRIPTION
## Summary

Turns the existing coverage report into a build gate that blocks merges: Vitest now enforces global and per-module coverage thresholds, and exits non-zero when they are not met. Adds the CI status badge to the README and documents the ratchet policy agreed in the Sprint 5 retrospective.

## Type of change
- [ ] `feat` – new feature
- [ ] `fix` – bug fix
- [ ] `refactor` – code change that is neither a fix nor a feature
- [x] `docs` – documentation only
- [x] `test` – adding or updating tests
- [x] `chore` – build, config, dependencies

## Related issue / task

SCRUM-23 · HU-34 — https://kontroldevelopment.atlassian.net/browse/SCRUM-23

## What changed

**Ratchet policy (SCRUM-23), three rules:**

1. **70% per critical module** — POS, budget, auth and reports.
2. **Global threshold pinned to the measured baseline**, no margin. It can hold or rise, never fall.
3. **+5 percentage points per sprint** on the global threshold.

**Thresholds now enforced.** Baseline measured 2026-08-12.

| | Statements | Branches | Functions | Lines |
|---|---|---|---|---|
| Backend — this PR | 33 | 21 | 23 | 33 |
| Backend — next sprint | 38 | 26 | 28 | 38 |
| Frontend — this PR | 80 | 80 | 75 | 83 |
| Frontend — next sprint | 85 | 85 | 80 | 88 |

Per critical module, 70% on all four metrics:

| Module | Files |
|---|---|
| POS | `frontend/src/utils/sales.js` |
| Budget | `backend/src/utils/budgetCalculations.js` |
| Auth | `backend/src/middleware/require{Auth,Role}.js` |
| Reports | `backend/src/controllers/reportsController.js`, `routes/reportsRoutes.js`, `schemas/reportsSchemas.js` |

`frontend/src/stores/auth.js` carries a lower temporary step (60/55/55/60) because it measures 66.66/60.41/59.25/69.73 today; it moves to 70 once `authStore.test.js` grows.

**New tests for the reports module.** Reports was the one critical module below 70%, which would have left the backend job red. Rather than lower the bar or defer it, `backend/tests/reports.controller.test.js` adds 21 cases across all six handlers — each on its success, not-found and database-failure path — plus the three progress branches of `getCompanySummary` and the company totals.

| File | Before | After |
|---|---|---|
| `reportsController.js` | 29.85 / 14.28 / 20 / 29.85 | **100 / 100 / 100 / 100** |
| `reportsSchemas.js` | 80 / 100 / 0 / 80 | **100 / 100 / 100 / 100** |
| `reportsRoutes.js` | 100 | 100 |

Backend global rose from 29.08/19.16/17.88/29.13 to 33.42/21.33/23.84/33.71 as a result, and the threshold was raised with it per rule 2.

**README** gets the CI badge at the top and a new "Cobertura de código" section documenting the policy.

**`ci.yml` is untouched.** The gate already works: the step is a plain `run:`, so a non-zero exit from Vitest fails the job. The `if: always()` upload still gets its artifact, because the report is written before thresholds are checked.

## Testing

```
npm run test:coverage -w backend    # 7 files, 80 tests, exit 0
npm run test:coverage -w frontend   # 6 files, 62 tests, exit 0
```

Gate verified to actually fail, using CLI overrides so nothing in the repo changes:

```
$ npm run test:coverage -w backend -- --coverage.thresholds.lines=95
  Tests  80 passed (80)
  ERROR: Coverage for lines (33.71%) does not meet global threshold (95%)
  exit=1
```

All tests pass in that run — the red build comes from the gate, not from broken tests.

Glob matching was verified rather than assumed, since a threshold glob that matches no file passes silently: forcing `sales.js` to 99% branches reports 94.44%, its exact measured value; and `require{Auth,Role}.js` passes at 99% statements while `require{Auth,Role,Company}.js` fails at 75.67%, confirming brace expansion selects the intended files and excludes the rest.

- [x] Tested manually (Postman / browser) — n/a, no runtime behaviour changed
- [x] Unit tests pass
- [x] No regressions on existing endpoints

## Checklist
- [x] Branch follows naming convention (`type/short-description`)
- [x] Commits follow Conventional Commits (`type(scope): message`)
- [x] No secrets or credentials committed
- [x] `password_hash` or sensitive fields are not exposed in responses
- [x] `.env.example` updated if new env vars were added — n/a, none added

## Notes for the reviewer

- **`coverage.all` no longer exists in Vitest 4.** No `coverage.include` is declared, so only files imported by a test are measured; untested files do not drag the percentage down. This is deliberate — it keeps the gate stable while code without tests lands.
- **The frontend has no margin.** 80/80/75/83 against a baseline of 80.95/80.46/75.51/83.10, on a denominator of only 168 statements across 6 files. Losing `Button.vue` coverage alone would take functions from 75.51% to 69.39%. Some PRs touching covered files may need to raise coverage in the same change.
- **A threshold glob matching no file passes vacuously.** The frontend reports globs are in that state today. Documented in both configs.
